### PR TITLE
Fix README since BreakOut pretrained model doesn't match the correct …

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ python -m baselines.deepq.experiments.atari.download_model
 Once you pick a model, you can download it and visualize the learned policy. Be sure to pass `--dueling` flag to visualization script when using dueling models.
 
 ```bash
-python -m baselines.deepq.experiments.atari.download_model --blob model-atari-prior-duel-breakout-1 --model-dir /tmp/models
-python -m baselines.deepq.experiments.atari.enjoy --model-dir /tmp/models/model-atari-prior-duel-breakout-1 --env Breakout --dueling
+python -m baselines.deepq.experiments.atari.download_model --blob model-atari-duel-pong-1 --model-dir /tmp/models
+python -m baselines.deepq.experiments.atari.enjoy --model-dir /tmp/models/model-atari-duel-pong-1 --env Pong --dueling
+
 ```


### PR DESCRIPTION
…tensor shape. Therefore, Pong is used instead.