### PR TITLE
Fix pposgd and trpo_mpi import module issue

### DIFF
--- a/baselines/pposgd/__init__.py
+++ b/baselines/pposgd/__init__.py
@@ -1,0 +1,1 @@
+from baselines.pposgd import cnn_policy, mlp_policy, pposgd_simple

--- a/baselines/trpo_mpi/__init__.py
+++ b/baselines/trpo_mpi/__init__.py
@@ -1,0 +1,1 @@
+from baselines.pposgd import cnn_policy, mlp_policy, pposgd_simple


### PR DESCRIPTION
I have a problem that I cannot find modules trpo and ppo after pip install. I use virtualenv for python 3.6 in mac os10.11. I think add '__ init__' files into pposgd and trpo_mpi folders will add the two module into python package when do pip install. I notice that in deepq and other modules there exist the '__init__' files.