### PR TITLE
Save, Load, & Visualize PPO results

### DIFF
--- a/baselines/pposgd/README.md
+++ b/baselines/pposgd/README.md
@@ -1,0 +1,8 @@
+## If you are curious.
+
+#### Train a Cartpole agent
+
+```bash
+python run_cartpole.py
+python enjoy_cartpole.py
+```

--- a/baselines/pposgd/enjoy_cartpole.py
+++ b/baselines/pposgd/enjoy_cartpole.py
@@ -18,17 +18,16 @@ def enjoy(env_id, num_timesteps, seed):
         return mlp_policy.MlpPolicy(name=name, ob_space=ob_space, ac_space=ac_space,
             hid_size=64, num_hid_layers=2)
     env = bench.Monitor(env, osp.join(logger.get_dir(), "monitor.json"))
+    obs = env.reset()
     env.seed(seed)
     gym.logger.setLevel(logging.WARN)
     pi = policy_fn('pi', env.observation_space, env.action_space)
-    saver = tf.train.Saver()
-    with tf.Session() as ses:
-        saver.restore('/tmp/model')
-        done = False
-        while not done:
-            action = pi.act(True, obs)[0]
-            obs, reward, done, info = env.step(action)
-            env.render()
+    tf.train.Saver().restore(sess, '/tmp/model')
+    done = False
+    while not done:
+        action = pi.act(True, obs)[0]
+        obs, reward, done, info = env.step(action)
+        env.render()
 
 def main():
     enjoy('CartPole-v1', num_timesteps=1e6, seed=0)

--- a/baselines/pposgd/enjoy_cartpole.py
+++ b/baselines/pposgd/enjoy_cartpole.py
@@ -1,0 +1,38 @@
+# !/usr/bin/env python
+from baselines.common import set_global_seeds, tf_util as U
+from baselines import bench
+import os.path as osp
+import gym, logging
+from baselines import logger
+import sys
+import tensorflow as tf
+
+def enjoy(env_id, num_timesteps, seed):
+    from baselines.pposgd import mlp_policy, pposgd_simple
+    sess = U.make_session(num_cpu=1)
+    sess.__enter__()
+    logger.session().__enter__()
+    set_global_seeds(seed)
+    env = gym.make(env_id)
+    def policy_fn(name, ob_space, ac_space):
+        return mlp_policy.MlpPolicy(name=name, ob_space=ob_space, ac_space=ac_space,
+            hid_size=64, num_hid_layers=2)
+    env = bench.Monitor(env, osp.join(logger.get_dir(), "monitor.json"))
+    env.seed(seed)
+    gym.logger.setLevel(logging.WARN)
+    pi = policy_fn('pi', env.observation_space, env.action_space)
+    saver = tf.train.Saver()
+    with tf.Session() as ses:
+        saver.restore('/tmp/model')
+        done = False
+        while not done:
+            action = pi.act(True, obs)[0]
+            obs, reward, done, info = env.step(action)
+            env.render()
+
+def main():
+    enjoy('CartPole-v1', num_timesteps=1e6, seed=0)
+
+
+if __name__ == '__main__':
+    main()

--- a/baselines/pposgd/run_cartpole.py
+++ b/baselines/pposgd/run_cartpole.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+from baselines.common import set_global_seeds, tf_util as U
+from baselines import bench
+import os.path as osp
+import gym, logging
+from baselines import logger
+import sys
+import tensorflow as tf
+
+def train(env_id, num_timesteps, seed):
+    from baselines.pposgd import mlp_policy, pposgd_simple
+    sess = U.make_session(num_cpu=1)
+    sess.__enter__()
+    logger.session().__enter__()
+    set_global_seeds(seed)
+    env = gym.make(env_id)
+    def policy_fn(name, ob_space, ac_space):
+        return mlp_policy.MlpPolicy(name=name, ob_space=ob_space, ac_space=ac_space,
+            hid_size=64, num_hid_layers=2)
+    env = bench.Monitor(env, osp.join(logger.get_dir(), "monitor.json"))
+    env.seed(seed)
+    gym.logger.setLevel(logging.WARN)
+    pposgd_simple.learn(env, policy_fn,
+            max_timesteps=num_timesteps,
+            timesteps_per_batch=2048,
+            clip_param=0.2, entcoeff=0.0,
+            optim_epochs=10, optim_stepsize=3e-4, optim_batchsize=64,
+            gamma=0.99, lam=0.95,
+        )
+    env.close()
+    saver = tf.train.Saver()
+    saver.save(sess, '/tmp/model')
+
+def main():
+    print("Start")
+    train('CartPole-v1', num_timesteps=1e6, seed=0)
+
+if __name__ == "__main__":
+    main()

--- a/baselines/pposgd/run_cartpole.py
+++ b/baselines/pposgd/run_cartpole.py
@@ -32,7 +32,6 @@ def train(env_id, num_timesteps, seed):
     saver.save(sess, '/tmp/model')
 
 def main():
-    print("Start")
     train('CartPole-v1', num_timesteps=1e6, seed=0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed in Issue #74, the code given for PPO trains the agent without saving its results, which can be confusing for newcomers. This pull requests adds two files that allow someone to train a PPO-based agent on the CartPole task and then load up the model and see the agent playing in real time. I also added a README file so that instructions on how to use the code can be clearly stated.

## Improvements
I'm not sure strictly how much of the setup from the training process needs to be duplicated in the visualizing process, but I included all of it so that it doesn't break.

It would also be more user-friendly if the training process returned an `ActWrapper`, but I wasn't sure how to do that.