### PR TITLE
fix _demo() in logger, patch for python2 support

### DIFF
--- a/baselines/common/dataset.py
+++ b/baselines/common/dataset.py
@@ -47,7 +47,7 @@ class Dataset(object):
         return Dataset(data_map, deterministic)
 
 
-def iterbatches(arrays, *, num_batches=None, batch_size=None, shuffle=True, include_final_partial_batch=True):
+def iterbatches(arrays, num_batches=None, batch_size=None, shuffle=True, include_final_partial_batch=True, **kwargs):
     assert (num_batches is None) != (batch_size is None), 'Provide num_batches or batch_size, but not both'
     arrays = tuple(map(np.asarray, arrays))
     n = arrays[0].shape[0]

--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -170,11 +170,12 @@ def getkvs():
     return Logger.CURRENT.name2val    
 
 
-def log(*args, level=INFO):
+def log(*args, **kwargs):
     """
     Write the sequence of args, with no separators, to the console and output files (if you've configured an output file).
     """
-    Logger.CURRENT.log(*args, level=level)
+    level = kwargs['level'] if 'level' in kwargs else INFO
+    Logger.CURRENT.log(level=level, *args)
 
 
 def debug(*args):
@@ -235,7 +236,7 @@ class Logger(object):
             fmt.writekvs(self.name2val)
         self.name2val.clear()
 
-    def log(self, *args, level=INFO):
+    def log(self, level=INFO, *args):
         if self.level <= level:
             self._do_log(args)
 


### PR DESCRIPTION
Baselines don't support python2 officially, but small improvement makes better readability and python2 support.

I Love Python3, sometimes I need to write up python 2 code.

Opensim works only python2
ex) https://www.crowdai.org/challenges/nips-2017-learning-to-run