### PR TITLE
Generalized advantages for a2c. Kept lambda=1 by default.

### DIFF
--- a/baselines/a2c/a2c.py
+++ b/baselines/a2c/a2c.py
@@ -91,7 +91,7 @@ class Model(object):
 
 class Runner(object):
 
-    def __init__(self, env, model, nsteps=5, nstack=4, gamma=0.99):
+    def __init__(self, env, model, nsteps=5, nstack=4, gamma=0.99, _lambda=1.0):
         self.env = env
         self.model = model
         nh, nw, nc = env.observation_space.shape
@@ -101,6 +101,7 @@ class Runner(object):
         obs = env.reset()
         self.update_obs(obs)
         self.gamma = gamma
+        self._lambda = _lambda
         self.nsteps = nsteps
         self.states = model.initial_state
         self.dones = [False for _ in range(nenv)]
@@ -139,13 +140,13 @@ class Runner(object):
         mb_dones = mb_dones[:, 1:]
         last_values = self.model.value(self.obs, self.states, self.dones).tolist()
         #discount/bootstrap off value fn
-        for n, (rewards, dones, value) in enumerate(zip(mb_rewards, mb_dones, last_values)):
-            rewards = rewards.tolist()
-            dones = dones.tolist()
-            if dones[-1] == 0:
-                rewards = discount_with_dones(rewards+[value], dones+[0], self.gamma)[:-1]
-            else:
-                rewards = discount_with_dones(rewards, dones, self.gamma)
+        for n, (rewards, dones, values, value) in enumerate(zip(mb_rewards, mb_dones, mb_values, last_values)):
+            values_appended = np.asarray(values.tolist() + [value if dones[-1]==0 else 0])
+            dones_appended = np.asarray(dones.tolist() + [0])
+            one_step_advantages = rewards + (1 - dones_appended[:-1]) * self.gamma * values_appended[1:] - values_appended[:-1]
+            generalized_advantages = discount_with_dones(one_step_advantages, dones, self.gamma * self._lambda)
+            # generalized_advantages becomes same as (nstep discounted returns - values) when _lambda=1 (as in standard A2C/A3C implementation)
+            rewards = values + np.asarray(generalized_advantages)
             mb_rewards[n] = rewards
         mb_rewards = mb_rewards.flatten()
         mb_actions = mb_actions.flatten()
@@ -153,7 +154,7 @@ class Runner(object):
         mb_masks = mb_masks.flatten()
         return mb_obs, mb_states, mb_rewards, mb_masks, mb_actions, mb_values
 
-def learn(policy, env, seed, nsteps=5, nstack=4, total_timesteps=int(80e6), vf_coef=0.5, ent_coef=0.01, max_grad_norm=0.5, lr=7e-4, lrschedule='linear', epsilon=1e-5, alpha=0.99, gamma=0.99, log_interval=100):
+def learn(policy, env, seed, nsteps=5, nstack=4, total_timesteps=int(80e6), vf_coef=0.5, ent_coef=0.01, max_grad_norm=0.5, lr=7e-4, lrschedule='linear', epsilon=1e-5, alpha=0.99, gamma=0.99, _lambda=1.0, log_interval=100):
     tf.reset_default_graph()
     set_global_seeds(seed)
 
@@ -163,7 +164,7 @@ def learn(policy, env, seed, nsteps=5, nstack=4, total_timesteps=int(80e6), vf_c
     num_procs = len(env.remotes) # HACK
     model = Model(policy=policy, ob_space=ob_space, ac_space=ac_space, nenvs=nenvs, nsteps=nsteps, nstack=nstack, num_procs=num_procs, ent_coef=ent_coef, vf_coef=vf_coef,
         max_grad_norm=max_grad_norm, lr=lr, alpha=alpha, epsilon=epsilon, total_timesteps=total_timesteps, lrschedule=lrschedule)
-    runner = Runner(env, model, nsteps=nsteps, nstack=nstack, gamma=gamma)
+    runner = Runner(env, model, nsteps=nsteps, nstack=nstack, gamma=gamma, _lambda=_lambda)
 
     nbatch = nenvs*nsteps
     tstart = time.time()


### PR DESCRIPTION
Added option of using generalized advantage estimates (GAE) for a2c. Equivalent to eligibility traces. By default, I have kept lambda = 1 .. i.e. GAE turned off by default. So this should not change the default reproducibility of the results.
lambda = 0 means using one step advantages
lambda = 1 means using n step advantages (here by default n = 5)
Intermediate values of lambda should create a superposition effect of different length advantages.

I have tested the code with python 3.5 on Windows 10.
In the cartpole-v0 env, on using lambda=0.8, greater stability was observed in rewards per episode graph.
