### PR TITLE
Allow callback in acktr to use locals and globals

### DIFF
--- a/baselines/acktr/acktr_cont.py
+++ b/baselines/acktr/acktr_cont.py
@@ -133,6 +133,6 @@ def learn(env, policy, vf, gamma, lam, timesteps_per_batch, num_timesteps,
         logger.record_tabular("EpLenMean", np.mean([pathlength(path) for path in paths]))
         logger.record_tabular("KL", kl)
         if callback:
-            callback()
+            callback(locals(), globals())
         logger.dump_tabular()
         i += 1


### PR DESCRIPTION
Making the `learn` interface more consistent with ppo and trpo