### PR TITLE
Added ability to save and restore the trained model states for PPO.

### DIFF
--- a/baselines/ppo1/run_atari.py
+++ b/baselines/ppo1/run_atari.py
@@ -13,7 +13,7 @@ def wrap_train(env):
     env = FrameStack(env, 4)
     return env
 
-def train(env_id, num_frames, seed):
+def train(env_id, num_frames, seed, save_model_with_prefix, restore_model_from_file):
     from baselines.ppo1 import pposgd_simple, cnn_policy
     import baselines.common.tf_util as U
     rank = MPI.COMM_WORLD.Get_rank()
@@ -40,7 +40,9 @@ def train(env_id, num_frames, seed):
         clip_param=0.2, entcoeff=0.01,
         optim_epochs=4, optim_stepsize=1e-3, optim_batchsize=64,
         gamma=0.99, lam=0.95,
-        schedule='linear'
+        schedule='linear',
+        save_model_with_prefix=save_model_with_prefix,
+        restore_model_from_file=restore_model_from_file
     )
     env.close()
 
@@ -49,8 +51,11 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--env', help='environment ID', default='PongNoFrameskip-v4')
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
+    parser.add_argument('--save_model_with_prefix', help='Specify a prefix name to save the model with after every 500 iters. Note that this will generate multiple files (*.data, *.index, *.meta and checkpoint) with the same prefix', default='')
+    parser.add_argument('--restore_model_from_file', help='Specify the absolute path to the model file including the file name upto .model (without the .data-00000-of-00001 suffix). make sure the *.index and the *.meta files for the model exists in the specified location as well', default='')
+
     args = parser.parse_args()
-    train(args.env, num_frames=40e6, seed=args.seed)
+    train(args.env, num_frames=40e6, seed=args.seed, save_model_with_prefix=args.save_model_with_prefix, restore_model_from_file=args.restore_model_from_file)
 
 if __name__ == '__main__':
     main()

--- a/baselines/ppo1/run_mujoco.py
+++ b/baselines/ppo1/run_mujoco.py
@@ -6,7 +6,7 @@ import gym, logging
 from baselines import logger
 import sys
 
-def train(env_id, num_timesteps, seed):
+def train(env_id, num_frames, seed, save_model_with_prefix, restore_model_from_file):
     from baselines.ppo1 import mlp_policy, pposgd_simple
     U.make_session(num_cpu=1).__enter__()
     set_global_seeds(seed)
@@ -24,6 +24,9 @@ def train(env_id, num_timesteps, seed):
             clip_param=0.2, entcoeff=0.0,
             optim_epochs=10, optim_stepsize=3e-4, optim_batchsize=64,
             gamma=0.99, lam=0.95, schedule='linear',
+            save_model_with_prefix=save_model_with_prefix,
+            restore_model_from_file=restore_model_from_file
+
         )
     env.close()
 
@@ -32,8 +35,10 @@ def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--env', help='environment ID', default='Hopper-v1')
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
-    args = parser.parse_args()
-    train(args.env, num_timesteps=1e6, seed=args.seed)
+    parser.add_argument('--save_model_with_prefix', help='Specify a prefix name to save the model with after every 500 iters. Note that this will generate multiple files (*.data, *.index, *.meta and checkpoint) with the same prefix', default='')
+    parser.add_argument('--restore_model_from_file', help='Specify the absolute path to the model file including the file name upto .model (without the .data-00000-of-00001 suffix). make sure the *.index and the *.meta files for the model exists in the specified location as well', default='')
+   args = parser.parse_args()
+    train(args.env, num_timesteps=1e6, seed=args.seed, save_model_with_prefix=args.save_model_with_prefix, restore_model_from_file=args.restore_model_from_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes it easy to resume training by saving and restoring checkpoints along the training process.

**Contributions:**

-  Added Command line argument to specify a prefix for the model file name to save the state. By default, if `save_model_with_prefix` is specified, the current state after every 500 iterations is saved to a file named "`save_model_with_prefix`\_afterIter\_`iters_so_far`.model" in the same directory as the run script.

- Added Command line argument to specify the name of the model file to load states from and resume training from that state.

- Updated `run_atari.py`, `run_mujoco.py`  and `pposgd_simple` as necessary to add the save and restore capability.

- Tested with both `run_atari` and `run_mujoco` tasks.

- Added descriptive help text/docstring to argparser 