### PR TITLE
remove ref to simple_bench + rank variable not used [mpi gone]

### DIFF
--- a/baselines/acktr/run_atari.py
+++ b/baselines/acktr/run_atari.py
@@ -13,7 +13,7 @@ def train(env_id, num_timesteps, seed, num_cpu):
         def _thunk():
             env = make_atari(env_id)
             env.seed(seed + rank)
-            env = bench.Monitor(env, logger.get_dir() and os.path.join(logger.get_dir(), str(rank)))
+            env = bench.Monitor(env, logger.get_dir() and logger.get_dir())
             gym.logger.setLevel(logging.WARN)
             return wrap_deepmind(env)
         return _thunk

--- a/baselines/bench/__init__.py
+++ b/baselines/bench/__init__.py
@@ -1,3 +1,2 @@
 from baselines.bench.benchmarks import *
 from baselines.bench.monitor import *
-from baselines.bench.simple_bench import simple_bench


### PR DESCRIPTION
Two minor fixes to baselines:
- remove reference to simple_bench
- remove reference to rank