### PR TITLE
Force shebang lines to Python 3

### DIFF
--- a/baselines/a2c/run_atari.py
+++ b/baselines/a2c/run_atari.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, logging, gym
 from baselines import logger
 from baselines.common import set_global_seeds

--- a/baselines/acktr/run_atari.py
+++ b/baselines/acktr/run_atari.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os, logging, gym
 from baselines import logger
 from baselines.common import set_global_seeds

--- a/baselines/acktr/run_mujoco.py
+++ b/baselines/acktr/run_mujoco.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import logging
 import os

--- a/baselines/ppo1/run_atari.py
+++ b/baselines/ppo1/run_atari.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from mpi4py import MPI
 from baselines.common import set_global_seeds

--- a/baselines/ppo1/run_mujoco.py
+++ b/baselines/ppo1/run_mujoco.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from baselines.common import set_global_seeds, tf_util as U
 from baselines import bench
 import gym, logging

--- a/baselines/trpo_mpi/run_atari.py
+++ b/baselines/trpo_mpi/run_atari.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/env python
+#!/usr/bin/env python3
 from mpi4py import MPI
 from baselines.common import set_global_seeds
 import os.path as osp

--- a/baselines/trpo_mpi/run_mujoco.py
+++ b/baselines/trpo_mpi/run_mujoco.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # noinspection PyUnresolvedReferences
 import mujoco_py # Mujoco must come before other imports. https://openai.slack.com/archives/C1H6P3R7B/p1492828680631850
 from mpi4py import MPI


### PR DESCRIPTION
This is a Python 3-only library. A shebang with `#!/usr/bin/env python`
will launch python2 on many systems which do not have python3
installed. Setting the shebang to `#!/usr/bin/env python3` will show a
useful error on systems without Python 3.