### PR TITLE
Fix A2C crash on OS X High Sierra

### DIFF
--- a/baselines/a2c/a2c.py
+++ b/baselines/a2c/a2c.py
@@ -16,6 +16,12 @@ from baselines.a2c.utils import Scheduler, make_path, find_trainable_variables
 from baselines.a2c.policies import CnnPolicy
 from baselines.a2c.utils import cat_entropy, mse
 
+# On OS X, certain Objective-C runtime classes must be initialised before any
+# threads are created if they are to be used in forked process. See commit
+# comments for more details.
+from cv2.ocl import useOpenCL
+useOpenCL()
+
 class Model(object):
 
     def __init__(self, policy, ob_space, ac_space, nenvs, nsteps, nstack, num_procs,


### PR DESCRIPTION
Behaviour of the Objective-C runtime after fork() has changed in OS X High Sierra.
Specifically, class initializers will refuse to run in a child process forked
from a multithreaded parent. Some details are available at:

<http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html>

This leads to a crash like:

```
objc[1306]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called.
objc[1306]: +[__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
```

but this message is a little misleading: the runtime doesn't really check
whether the initialize function is really in progress; it just goes, "Am I in a
process forked from a multithreaded parent? If so, I have no idea what might be
going on in those other threads, so I'm going to crash just to be safe." For
full details search for 'MultithreadedForkChild' in

<https://opensource.apple.com/source/objc4/objc4-723/runtime/objc-initialize.mm.auto.html>

This leads to a crash with A2C because:
- TensorFlow session creation creates some threads (I think)
- In the forked worker processes, the WarpFrame wrapper calls cvtColor in OpenCV
- At some point cvtColor calls useOpenCL in OpenCV
- useOpenCL somehow involves the Objective-C runtime, leading to the crash

The solution is to initialise the relevant Objective-C classes before any
threads are created in the parent process. We do this by calling useOpenCL
directly right at the start.