### PR TITLE
Docstring fix

### DIFF
--- a/baselines/deepq/replay_buffer.py
+++ b/baselines/deepq/replay_buffer.py
@@ -6,7 +6,7 @@ from baselines.common.segment_tree import SumSegmentTree, MinSegmentTree
 
 class ReplayBuffer(object):
     def __init__(self, size):
-        """Create Prioritized Replay buffer.
+        """Create Replay buffer.
 
         Parameters
         ----------


### PR DESCRIPTION
The `ReplayBuffer` class docstring stated that it implemented a prioritized replay buffer, and not the vanilla version.