### PR TITLE
Call ppo2 and not ppo1 in ppo2 README.md

### DIFF
--- a/baselines/ppo2/README.md
+++ b/baselines/ppo2/README.md
@@ -2,5 +2,5 @@
 
 - Original paper: https://arxiv.org/abs/1707.06347
 - Baselines blog post: https://blog.openai.com/openai-baselines-ppo/
-- `mpirun -np 8 python -m baselines.ppo1.run_atari` runs the algorithm for 40M frames = 10M timesteps on an Atari game. See help (`-h`) for more options.
-- `python -m baselines.ppo1.run_mujoco` runs the algorithm for 1M frames on a Mujoco environment.
+- `mpirun -np 8 python -m baselines.ppo2.run_atari` runs the algorithm for 40M frames = 10M timesteps on an Atari game. See help (`-h`) for more options.
+- `python -m baselines.ppo2.run_mujoco` runs the algorithm for 1M frames on a Mujoco environment.


### PR DESCRIPTION
Only found this typo after I copy-pasted the command and the GPU OOM'd even though the ppo2 code has the TF GPU growth option enabled.