### PR TITLE
make trpo returns consistent with ppo returns

### DIFF
--- a/baselines/trpo_mpi/trpo_mpi.py
+++ b/baselines/trpo_mpi/trpo_mpi.py
@@ -180,8 +180,8 @@ def learn(env, policy_func, *,
     timesteps_so_far = 0
     iters_so_far = 0
     tstart = time.time()
-    lenbuffer = deque(maxlen=40) # rolling buffer for episode lengths
-    rewbuffer = deque(maxlen=40) # rolling buffer for episode rewards
+    lenbuffer = deque(maxlen=100) # rolling buffer for episode lengths
+    rewbuffer = deque(maxlen=100) # rolling buffer for episode rewards
 
     assert sum([max_iters>0, max_timesteps>0, max_episodes>0])==1
 


### PR DESCRIPTION
Currently the calculation for returns is different between these two algorithms due to different buffer lengths. The same experience given to both algorithms logs different results. This change will allow comparisons to be more valid.