### PR TITLE
Add support for different activations for DQN

### DIFF
--- a/baselines/deepq/models.py
+++ b/baselines/deepq/models.py
@@ -2,32 +2,35 @@ import tensorflow as tf
 import tensorflow.contrib.layers as layers
 
 
-def _mlp(hiddens, inpt, num_actions, scope, reuse=False, layer_norm=False):
+def _mlp(hiddens, inpt, num_actions, scope, reuse=False, layer_norm=False, activation_fn=tf.nn.relu):
     with tf.variable_scope(scope, reuse=reuse):
         out = inpt
         for hidden in hiddens:
             out = layers.fully_connected(out, num_outputs=hidden, activation_fn=None)
             if layer_norm:
                 out = layers.layer_norm(out, center=True, scale=True)
-            out = tf.nn.relu(out)
+            out = activation_fn(out)
         q_out = layers.fully_connected(out, num_outputs=num_actions, activation_fn=None)
         return q_out
 
 
-def mlp(hiddens=[], layer_norm=False):
+def mlp(hiddens=[], activation_fn=tf.nn.relu, layer_norm=False):
     """This model takes as input an observation and returns values of all actions.
 
     Parameters
     ----------
     hiddens: [int]
         list of sizes of hidden layers
+    activation_fn
+        activation function to use (ex: tf.nn.relu)
 
     Returns
     -------
     q_func: function
         q_function for DQN algorithm.
     """
-    return lambda *args, **kwargs: _mlp(hiddens, layer_norm=layer_norm, *args, **kwargs)
+    return lambda *args, **kwargs: _mlp(hiddens, layer_norm=layer_norm,
+            activation_fn=activation_fn, *args, **kwargs)
 
 
 def _cnn_to_mlp(convs, hiddens, dueling, inpt, num_actions, scope, reuse=False, layer_norm=False):


### PR DESCRIPTION
I found it handy in my projects to try different activations. This commit adds support for that (e.g. `model = deepq.models.mlp([64], activation_fn=tf.nn.tanh)`).