### PR TITLE
Fixed name of default MuJoCo environment

### DIFF
--- a/baselines/common/cmd_util.py
+++ b/baselines/common/cmd_util.py
@@ -58,7 +58,7 @@ def mujoco_arg_parser():
     Create an argparse.ArgumentParser for run_mujoco.py.
     """
     parser = arg_parser()
-    parser.add_argument('--env', help='environment ID', type=str, default="Reacher-v1")
+    parser.add_argument('--env', help='environment ID', type=str, default="Reacher-v2")
     parser.add_argument('--seed', help='RNG seed', type=int, default=0)
     parser.add_argument('--num-timesteps', type=int, default=int(1e6))
     return parser


### PR DESCRIPTION
Gym environment "Reacher-v1" is retired. So, if a MuJoCo environment is not specified in the arguments, and the code is run for the default environment, it would not work. To resolve the issue the default environment is changed to "Reacher-v2".