### PR TITLE
case-insensitive sort for human-readable logger

### DIFF
--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -56,7 +56,7 @@ class HumanOutputFormat(KVWriter, SeqWriter):
         # Write out the data
         dashes = '-' * (keywidth + valwidth + 7)
         lines = [dashes]
-        for (key, val) in sorted(key2str.items()):
+        for (key, val) in sorted(key2str.items(), key=lambda kv: kv[0].lower()):
             lines.append('| %s%s | %s%s |' % (
                 key,
                 ' ' * (keywidth - len(key)),


### PR DESCRIPTION
This changes the human-readable tabular logger output from ASCII sort order to case-insensitive.

This makes it easier to locate specific values in the table, especially when you are logging lots of values.