### PR TITLE
Fix bug in DDPG parameter space noise adaptation

### DIFF
--- a/baselines/ddpg/training.py
+++ b/baselines/ddpg/training.py
@@ -109,7 +109,7 @@ def train(env, nb_epochs, nb_epoch_cycles, render_eval, reward_scale, render, pa
                 epoch_adaptive_distances = []
                 for t_train in range(nb_train_steps):
                     # Adapt param noise, if necessary.
-                    if memory.nb_entries >= batch_size and t % param_noise_adaption_interval == 0:
+                    if memory.nb_entries >= batch_size and t_train % param_noise_adaption_interval == 0:
                         distance = agent.adapt_param_noise()
                         epoch_adaptive_distances.append(distance)
 


### PR DESCRIPTION
The variable `t` here should be `t_train`. `t` is invariant for this loop, so `t % param_noise_adaption_interval == 0` will evaluate to the same thing each time. For the default values of the parameters `param_noise_adaption_interval` (50) and `nb_rollout_steps` (100), this causes the code to adapt the scale of the parameter space noise in every single training step, which is correct but slow.

(For other values of the parameters, the adaptation won't happen for long periods of time, which is a problem.)