### PR TITLE
Added train & enjoy scripts for the A2C algorithm

### DIFF
--- a/baselines/a2c/README.md
+++ b/baselines/a2c/README.md
@@ -2,4 +2,17 @@
 
 - Original paper: https://arxiv.org/abs/1602.01783
 - Baselines blog post: https://blog.openai.com/baselines-acktr-a2c/
-- `python -m baselines.a2c.run_atari` runs the algorithm for 40M frames = 10M timesteps on an Atari game. See help (`-h`) for more options.
+
+To run the algorithm on an Atari game (Breakout by default) for 40M frames = 10M timesteps:
+
+```shell
+python -m baselines.a2c.train_atari
+```
+
+Load the saved model and look at the trained policy:
+
+```shell
+python -m baselines.a2c.enjoy_atari
+```
+
+See help (`-h`) for more options.

--- a/baselines/a2c/enjoy_atari.py
+++ b/baselines/a2c/enjoy_atari.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+"""
+See trained A2C model in action.
+The parameters (env id, policy architecture, etc.) should be the same as in train_atari.py
+
+"""
+
+
+import time
+
+import tensorflow as tf
+
+from baselines import logger
+from baselines.a2c.a2c import Model
+from baselines.common.cmd_util import atari_arg_parser
+from baselines.common.vec_env.vec_frame_stack import VecFrameStack
+from baselines.common.atari_wrappers import make_atari, wrap_deepmind
+from baselines.ppo2.policies import CnnPolicy, LstmPolicy, LnLstmPolicy
+
+
+def enjoy(env_id, seed, policy, model_filename, fps=100):
+    if policy == 'cnn':
+        policy_fn = CnnPolicy
+    elif policy == 'lstm':
+        policy_fn = LstmPolicy
+    elif policy == 'lnlstm':
+        policy_fn = LnLstmPolicy
+
+    env = wrap_deepmind(make_atari(env_id), clip_rewards=False, frame_stack=True)
+    env.seed(seed)
+
+    tf.reset_default_graph()
+    ob_space = env.observation_space
+    ac_space = env.action_space
+    nsteps = 5  # default value, change if needed
+
+    model = Model(policy=policy_fn, ob_space=ob_space, ac_space=ac_space, nenvs=1, nsteps=nsteps)
+    model.load(model_filename)
+
+    while True:
+        obs, done = env.reset(), False
+        episode_rew = 0
+        while not done:
+            env.render()
+            time.sleep(1.0 / fps)
+            action, _, _, _ = model.step_model.step([obs.__array__()])
+            obs, rew, done, _ = env.step(action)
+            episode_rew += rew
+        print('Episode reward:', episode_rew)
+
+    env.close()
+
+
+def main():
+    parser = atari_arg_parser()
+    parser.add_argument('--policy', help='Policy architecture', choices=['cnn', 'lstm', 'lnlstm'], default='cnn')
+    parser.add_argument('--model-filename', help='Trained model filename', default='atari_a2c.gz')
+    args = parser.parse_args()
+    logger.configure()
+    enjoy(args.env, args.seed, args.policy, args.model_filename)
+
+
+if __name__ == '__main__':
+    main()

--- a/baselines/a2c/train_atari.py
+++ b/baselines/a2c/train_atari.py
@@ -6,7 +6,7 @@ from baselines.common.vec_env.vec_frame_stack import VecFrameStack
 from baselines.a2c.a2c import learn
 from baselines.ppo2.policies import CnnPolicy, LstmPolicy, LnLstmPolicy
 
-def train(env_id, num_timesteps, seed, policy, lrschedule, num_env):
+def train(env_id, num_timesteps, seed, policy, lrschedule, num_env, model_filename):
     if policy == 'cnn':
         policy_fn = CnnPolicy
     elif policy == 'lstm':
@@ -14,17 +14,25 @@ def train(env_id, num_timesteps, seed, policy, lrschedule, num_env):
     elif policy == 'lnlstm':
         policy_fn = LnLstmPolicy
     env = VecFrameStack(make_atari_env(env_id, num_env, seed), 4)
-    learn(policy_fn, env, seed, total_timesteps=int(num_timesteps * 1.1), lrschedule=lrschedule)
+    learn(
+        policy_fn, env, seed, total_timesteps=int(num_timesteps * 1.1),
+        lrschedule=lrschedule, model_filename=model_filename,
+    )
     env.close()
 
 def main():
     parser = atari_arg_parser()
     parser.add_argument('--policy', help='Policy architecture', choices=['cnn', 'lstm', 'lnlstm'], default='cnn')
     parser.add_argument('--lrschedule', help='Learning rate schedule', choices=['constant', 'linear'], default='constant')
+    parser.add_argument('--model-filename', help='Trained model filename', default='atari_a2c.gz')
     args = parser.parse_args()
     logger.configure()
-    train(args.env, num_timesteps=args.num_timesteps, seed=args.seed,
-        policy=args.policy, lrschedule=args.lrschedule, num_env=16)
+
+    train(
+        args.env, num_timesteps=args.num_timesteps, seed=args.seed,
+        policy=args.policy, lrschedule=args.lrschedule, num_env=16,
+        model_filename=args.model_filename,
+    )
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Replaced a single run_atari.py script in the A2C folder with a pair of scripts train_atari.py and enjoy_atari.py.
train_atari now saves the trained model to file, which can be used to visualize the trained policy with enjoy_atari.

Sorry to bother you with this lame pull request, but I wrote these scripts for myself to better understand the algorithm, and I hope they can be useful for someone else who is also learning RL.