### PR TITLE
retrainable her

### DIFF
--- a/baselines/her/experiment/config.py
+++ b/baselines/her/experiment/config.py
@@ -3,7 +3,6 @@ import numpy as np
 import json
 import os
 import gym
-
 from baselines import logger
 from baselines.her.ddpg import DDPG
 from baselines.her.her import make_sample_her_transitions

--- a/baselines/her/experiment/train.py
+++ b/baselines/her/experiment/train.py
@@ -5,6 +5,7 @@ import click
 import numpy as np
 import json
 from mpi4py import MPI
+import dill as pickle
 
 from baselines import logger
 from baselines.common import set_global_seeds
@@ -13,6 +14,22 @@ import baselines.her.experiment.config as config
 from baselines.her.rollout import RolloutWorker
 from baselines.her.util import mpi_fork
 
+def get_latest_pkl(logdir):
+    if(logdir==None):
+        print("enter with option --logdir")
+    policy_list = os.listdir(logdir)
+    latest_pkl_value = -1
+    latest_pkl_file = None
+    for pkl_file in policy_list:
+        if(pkl_file.startswith("policy_")):
+            pkl = pkl_file[7:]      #strip policy_
+            pkl = pkl[:-4]      #strip .pkl
+            if(pkl.isdigit()):
+                pkl_value = int(pkl)
+                if(pkl_value>latest_pkl_value):
+                    latest_pkl_value = pkl_value       
+                    latest_pkl_file = pkl_file
+    return latest_pkl_file,latest_pkl_value
 
 def mpi_average(value):
     if value == []:
@@ -24,16 +41,16 @@ def mpi_average(value):
 
 def train(policy, rollout_worker, evaluator,
           n_epochs, n_test_rollouts, n_cycles, n_batches, policy_save_interval,
-          save_policies, **kwargs):
+          save_policies,retrainable=False,retrain=False,start_epoch=0, **kwargs):
     rank = MPI.COMM_WORLD.Get_rank()
 
     latest_policy_path = os.path.join(logger.get_dir(), 'policy_latest.pkl')
     best_policy_path = os.path.join(logger.get_dir(), 'policy_best.pkl')
     periodic_policy_path = os.path.join(logger.get_dir(), 'policy_{}.pkl')
 
-    logger.info("Training...")
-    best_success_rate = -1
-    for epoch in range(n_epochs):
+    if(not(retrainable) or rank==0):
+        logger.info("Training...")
+    for epoch in range(start_epoch,n_epochs):
         # train
         rollout_worker.clear_history()
         for _ in range(n_cycles):
@@ -48,6 +65,7 @@ def train(policy, rollout_worker, evaluator,
         for _ in range(n_test_rollouts):
             evaluator.generate_rollouts()
 
+    
         # record logs
         logger.record_tabular('epoch', epoch)
         for key, val in evaluator.logs('test'):
@@ -56,22 +74,34 @@ def train(policy, rollout_worker, evaluator,
             logger.record_tabular(key, mpi_average(val))
         for key, val in policy.logs():
             logger.record_tabular(key, mpi_average(val))
-
-        if rank == 0:
+            
+        if(not(retrainable) or rank==0):
             logger.dump_tabular()
 
         # save the policy if it's better than the previous ones
         success_rate = mpi_average(evaluator.current_success_rate())
-        if rank == 0 and success_rate >= best_success_rate and save_policies:
-            best_success_rate = success_rate
-            logger.info('New best success rate: {}. Saving policy to {} ...'.format(best_success_rate, best_policy_path))
+        if success_rate >= evaluator.policy.best_success_rate and save_policies:
+            evaluator.policy.best_success_rate = success_rate
+            if(not(retrainable) or rank==0):
+                logger.info('New best success rate: {}. Saving policy to {} ...'.format(evaluator.policy.best_success_rate, best_policy_path))
             evaluator.save_policy(best_policy_path)
             evaluator.save_policy(latest_policy_path)
-        if rank == 0 and policy_save_interval > 0 and epoch % policy_save_interval == 0 and save_policies:
-            policy_path = periodic_policy_path.format(epoch)
-            logger.info('Saving periodic policy to {} ...'.format(policy_path))
-            evaluator.save_policy(policy_path)
 
+        if policy_save_interval > 0 and epoch % policy_save_interval == 0 and save_policies:
+            policy_path = periodic_policy_path.format(epoch)
+            if(not(retrainable) or rank==0):
+                logger.info('Saving periodic policy to {} ...'.format(policy_path))
+            evaluator.save_policy(policy_path)
+            if(retrainable and epoch>0):
+                old_policy_path = periodic_policy_path.format(epoch-policy_save_interval)
+                print("Removing replay buffer from the previous pkl")
+                with open(old_policy_path, 'rb') as f:
+                    old_policy = pickle.load(f)
+                old_policy.old_policy = True
+                with open(old_policy_path, 'wb') as f:
+                    pickle.dump(old_policy, f)  
+                with open(policy_path, 'rb') as f:
+                    evaluator.policy = pickle.load(f)
         # make sure that different threads have different seeds
         local_uniform = np.random.uniform(size=(1,))
         root_uniform = local_uniform.copy()
@@ -81,8 +111,8 @@ def train(policy, rollout_worker, evaluator,
 
 
 def launch(
-    env_name, logdir, n_epochs, num_cpu, seed, replay_strategy, policy_save_interval, clip_return,
-    override_params={}, save_policies=True
+    env_name, logdir, n_epochs, num_cpu, seed, replay_strategy, policy_save_interval, clip_return,batch_size,
+    rollout_batch_size,retrainable,override_params={}, save_policies=True
 ):
     # Fork for multi-CPU MPI implementation.
     if num_cpu > 1:
@@ -92,48 +122,74 @@ def launch(
         import baselines.common.tf_util as U
         U.single_threaded_session().__enter__()
     rank = MPI.COMM_WORLD.Get_rank()
-
+    
     # Configure logging
-    if rank == 0:
-        if logdir or logger.get_dir() is None:
-            logger.configure(dir=logdir)
+    if(retrainable):
+        assert logdir is not None
+        logdir=os.path.join(logdir,"cpu"+str(rank))
+        os.makedirs(logdir, exist_ok=True)
+        latest_policy_path , last_epoch = get_latest_pkl(logdir)
+        retrain = False
+        if(latest_policy_path is not None):
+            retrain = True
+        logger.configure(dir=logdir,retrain=retrain)
+        logdir = logger.get_dir()
     else:
-        logger.configure()
-    logdir = logger.get_dir()
-    assert logdir is not None
-    os.makedirs(logdir, exist_ok=True)
+        if rank == 0:
+            if logdir or logger.get_dir() is None:
+                logger.configure(dir=logdir)
+        else:
+            logger.configure()
+        logdir = logger.get_dir()
+        assert logdir is not None
+        os.makedirs(logdir, exist_ok=True)
 
     # Seed everything.
     rank_seed = seed + 1000000 * rank
     set_global_seeds(rank_seed)
 
     # Prepare params.
-    params = config.DEFAULT_PARAMS
-    params['env_name'] = env_name
-    params['replay_strategy'] = replay_strategy
-    if env_name in config.DEFAULT_ENV_PARAMS:
-        params.update(config.DEFAULT_ENV_PARAMS[env_name])  # merge env-specific parameters in
-    params.update(**override_params)  # makes it possible to override any parameter
-    with open(os.path.join(logger.get_dir(), 'params.json'), 'w') as f:
-        json.dump(params, f)
+    if (retrainable and retrain):
+        with open(os.path.join(logdir, 'params.json'), 'r') as f:
+            params = json.load(f)
+    else:   
+        params = config.DEFAULT_PARAMS
+        params['env_name'] = env_name
+        params['replay_strategy'] = replay_strategy
+        params['batch_size'] = batch_size
+        params['rollout_batch_size'] = rollout_batch_size
+        if env_name in config.DEFAULT_ENV_PARAMS:
+            params.update(config.DEFAULT_ENV_PARAMS[env_name])  # merge env-specific parameters in
+        params.update(**override_params)  # makes it possible to override any parameter
+        with open(os.path.join(logger.get_dir(), 'params.json'), 'w') as f:
+            json.dump(params, f)
     params = config.prepare_params(params)
-    config.log_params(params, logger=logger)
+    
+    if(not(retrainable) or rank==0):
+        config.log_params(params, logger=logger)
 
-    if num_cpu == 1:
-        logger.warn()
-        logger.warn('*** Warning ***')
-        logger.warn(
-            'You are running HER with just a single MPI worker. This will work, but the ' +
-            'experiments that we report in Plappert et al. (2018, https://arxiv.org/abs/1802.09464) ' +
-            'were obtained with --num_cpu 19. This makes a significant difference and if you ' +
-            'are looking to reproduce those results, be aware of this. Please also refer to ' + 
-            'https://github.com/openai/baselines/issues/314 for further details.')
-        logger.warn('****************')
-        logger.warn()
+    if(not(retrainable) or not(retrain)):
+        if(not(retrainable) or rank==0):
+            if num_cpu == 1:
+                logger.warn()
+                logger.warn('*** Warning ***')
+                logger.warn(
+                    'You are running HER with just a single MPI worker. This will work, but the ' +
+                    'experiments that we report in Plappert et al. (2018, https://arxiv.org/abs/1802.09464) ' +
+                    'were obtained with --num_cpu 19. This makes a significant difference and if you ' +
+                    'are looking to reproduce those results, be aware of this. Please also refer to ' + 
+                    'https://github.com/openai/baselines/issues/314 for further details.')
+                logger.warn('****************')
+                logger.warn()
 
     dims = config.configure_dims(params)
-    policy = config.configure_ddpg(dims=dims, params=params, clip_return=clip_return)
-
+    if(retrainable and retrain):
+        with open(os.path.join(logdir,latest_policy_path), 'rb') as f:
+            policy = pickle.load(f)
+    else:
+        policy = config.configure_ddpg(dims=dims, params=params, clip_return=clip_return)
+    policy.retrainable = retrainable
+    
     rollout_params = {
         'exploit': False,
         'use_target_net': False,
@@ -150,6 +206,10 @@ def launch(
         'T': params['T'],
     }
 
+    if(retrainable):
+        rollout_params['n_episodes'] = (last_epoch*params['n_test_rollouts']*rollout_batch_size)
+        eval_params['n_episodes'] = (last_epoch*params['n_test_rollouts']*rollout_batch_size)
+        
     for name in ['T', 'rollout_batch_size', 'gamma', 'noise_eps', 'random_eps']:
         rollout_params[name] = params[name]
         eval_params[name] = params[name]
@@ -160,12 +220,19 @@ def launch(
     evaluator = RolloutWorker(params['make_env'], policy, dims, logger, **eval_params)
     evaluator.seed(rank_seed)
 
-    train(
-        logdir=logdir, policy=policy, rollout_worker=rollout_worker,
-        evaluator=evaluator, n_epochs=n_epochs, n_test_rollouts=params['n_test_rollouts'],
-        n_cycles=params['n_cycles'], n_batches=params['n_batches'],
-        policy_save_interval=policy_save_interval, save_policies=save_policies)
-
+    if(retrainable):
+        train(
+            logdir=logdir, policy=policy, rollout_worker=rollout_worker,
+            evaluator=evaluator, n_epochs=n_epochs, n_test_rollouts=params['n_test_rollouts'],
+            n_cycles=params['n_cycles'], n_batches=params['n_batches'],
+            policy_save_interval=policy_save_interval, save_policies=save_policies,
+            retrainable=True,retrain=retrain,start_epoch=last_epoch+1)
+    else:    
+        train(
+            logdir=logdir, policy=policy, rollout_worker=rollout_worker,
+            evaluator=evaluator, n_epochs=n_epochs, n_test_rollouts=params['n_test_rollouts'],
+            n_cycles=params['n_cycles'], n_batches=params['n_batches'],
+            policy_save_interval=policy_save_interval, save_policies=save_policies)
 
 @click.command()
 @click.option('--env_name', type=str, default='FetchReach-v0', help='the name of the OpenAI Gym environment that you want to train on')
@@ -176,6 +243,10 @@ def launch(
 @click.option('--policy_save_interval', type=int, default=5, help='the interval with which policy pickles are saved. If set to 0, only the best and latest policy will be pickled.')
 @click.option('--replay_strategy', type=click.Choice(['future', 'none']), default='future', help='the HER replay strategy to be used. "future" uses HER, "none" disables HER.')
 @click.option('--clip_return', type=int, default=1, help='whether or not returns should be clipped')
+@click.option('--batch_size', type=int, default=256, help='mini batch_size')
+@click.option('--rollout_batch_size', type=int, default=2, help='number of rollouts generated')
+@click.option('--retrainable',is_flag=True,help='whether or not to store replay buffer. If stored than can retrain later using this option again. Necessary to pass logdir with this option')
+
 def main(**kwargs):
     launch(**kwargs)
 

--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -1,7 +1,7 @@
 from collections import deque
 
 import numpy as np
-import pickle
+import dill as pickle
 from mujoco_py import MujocoException
 
 from baselines.her.util import convert_episode_to_batch_major, store_args
@@ -12,7 +12,7 @@ class RolloutWorker:
     @store_args
     def __init__(self, make_env, policy, dims, logger, T, rollout_batch_size=1,
                  exploit=False, use_target_net=False, compute_Q=False, noise_eps=0,
-                 random_eps=0, history_len=100, render=False, **kwargs):
+                 random_eps=0, history_len=100, render=False,n_episodes=0, **kwargs):
         """Rollout worker generates experience by interacting with one or many environments.
 
         Args:
@@ -39,7 +39,7 @@ class RolloutWorker:
         self.success_history = deque(maxlen=history_len)
         self.Q_history = deque(maxlen=history_len)
 
-        self.n_episodes = 0
+        self.n_episodes = n_episodes
         self.g = np.empty((self.rollout_batch_size, self.dims['g']), np.float32)  # goals
         self.initial_o = np.empty((self.rollout_batch_size, self.dims['o']), np.float32)  # observations
         self.initial_ag = np.empty((self.rollout_batch_size, self.dims['g']), np.float32)  # achieved goals


### PR DESCRIPTION
We have implemented the retraining option for her. Below we describe how to use it and the changes that we have made in various files. 

To use retrainable mode --retrainable option can be used . For example - `python -m baselines.her.experiment.train --retrainable` would run the code on FetchReach env for 50 epochs and would save the replay buffer in the pickle too.
This option has been built upon your existing code so it won't affect the normal usage.

This retrainable functionality has 2 major use-cases 
1 A case like ours where training gets stopped frequently because of power issues.
2 To continue training from last checkpoint. Say we trained some environment for 100 epochs but it only achieved 75% accuracy, then we could continue training from there to say 50 more epochs.

Now along with replay buffer the pickle size got too big , around 100-150x bigger, so we decided to store the buffer for the latest periodic policy only. That is if currently policy_10.pkl is being saved then after saving it we reload policy_5.pkl and remove the buffer from it nd save it again. This way only the last file has the buffer along with policy_best and policy_latest.

We were facing trouble storing the replay buffer using pickle so we used it's extension dill. With it all we had to do was remove buffer and sample_her_transitions from the excluded names list and the dill library handled serialisation of buffer.

Apart from this we added 2 more options batch size and rollout batch size for her train based on the discussions in issue #314 of baselines.
 
Changes in particular files --------------

1. Train.py 
When using retrainable option, providing a log directory is necessary since storing it in tmp would be useless. Next we need to store experiences for all the mpi cores so we have made folders cpu0 , cpu1 and so on for each mpi process. 
Although we store pkls for all processes logging in log.txt is only done for the rank 0 process since otherwise all processes were printing on the console. 
The get_latest_pkl returns the latest policy_num.pkl file and the number of epochs done . Using these we continue training. 
We also pass n_episode to rollout constructor to maintain consistency in the log file.

2.Rollout.py
As mentioned above the n_episode is not initialised to 0 but passed as a parameter . And instead of pickle, dill is used.

3 Logger.py 
We had to change the common file logger.py so that log files are not overwritten on training. We have added retrain option in the function configure , make_output_format , HumanOutputFormat and CSVOutputFormat. When retrain is true log files would be appended. 
To make sure this doesn't affect other baselines algorithms we have set default retrain value to be False. In progress.csv the order of columns changes everytime but enforcing it would have required to change logger.py even more and we really wanted to avoid that.

4. Ddpg.py
We have mainly modified the set_state and get_state which are called during pickling. If retrainable mode is on then a new policy is saved with buffer. Then when we have to remove it's buffer it's old_policy flag is set in train() function in train.py and then when it is saved, it's saved without buffer.
We had to set reuse to True since we were reloading policies multiple times to remove replay buffer and all of them used same neural network parameters created in _create_network() function.
The from_pkl flag prevents the init from re-initialising the replay buffer and the best success rate of the policy.