### PR TITLE
Add support for custom implementations of logger KVWriters

### DIFF
--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -346,7 +346,7 @@ class Logger(object):
 
 Logger.DEFAULT = Logger.CURRENT = Logger(dir=None, output_formats=[HumanOutputFormat(sys.stdout)])
 
-def configure(dir=None, format_strs=None):
+def configure(dir=None, format_strs=None, custom_output_formats=None):
     if dir is None:
         dir = os.getenv('OPENAI_LOGDIR')
     if dir is None:
@@ -359,6 +359,12 @@ def configure(dir=None, format_strs=None):
         strs = os.getenv('OPENAI_LOG_FORMAT')
         format_strs = strs.split(',') if strs else LOG_OUTPUT_FORMATS
     output_formats = [make_output_format(f, dir) for f in format_strs]
+
+    if custom_output_formats is not None:
+        assert isinstance(custom_output_formats, list)
+        for custom_output_format in custom_output_formats:
+            assert isinstance(custom_output_format, KVWriter)
+        output_formats.extend(custom_output_formats)
 
     Logger.CURRENT = Logger(dir=dir, output_formats=output_formats)
     log('Logging to %s'%dir)


### PR DESCRIPTION
Currently users can only use predefined [stdout, tensorboard, log, json, csv] output formats.

In my early stages of development I am good with tensorboard, but later on we use other software for tracking and monitoring experiments. 

Ideally I would like to integrate with open ai logger output formats. In order to do that logger configure class needs to accept other formats than those predefined 5.