### PR TITLE
Fixed comment on example usage in jupyter-notebook

### DIFF
--- a/baselines/results_plotter.py
+++ b/baselines/results_plotter.py
@@ -65,9 +65,9 @@ def plot_results(dirs, num_timesteps, xaxis, task_name):
     plot_curves(xy_list, xaxis, task_name)
 
 # Example usage in jupyter-notebook
-# from baselines import log_viewer
+# from baselines import results_plotter
 # %matplotlib inline
-# log_viewer.plot_results(["./log"], 10e6, log_viewer.X_TIMESTEPS, "Breakout")
+# results_plotter.plot_results(["./log"], 10e6, results_plotter.X_TIMESTEPS, "Breakout")
 # Here ./log is a directory containing the monitor.csv files
 
 def main():


### PR DESCRIPTION
Cause of error: Import name must be results_plotter, not log_viewer.