### PR TITLE
Fix a bug in data loading

### DIFF
--- a/baselines/gail/dataset/mujoco_dset.py
+++ b/baselines/gail/dataset/mujoco_dset.py
@@ -56,7 +56,7 @@ class Mujoco_Dset(object):
             for l, x_i in zip(episode_length, x):
                 y[start_idx:(start_idx+l)] = x_i
                 start_idx += l
-                return y
+            return y
         self.obs = np.array(flatten(obs))
         self.acs = np.array(flatten(acs))
         self.rets = traj_data['ep_rets'][:traj_limitation]


### PR DESCRIPTION
Currently the for loop only processes one entry in the array, causing the flattened array to have all zeros after the first entry.