### PR TITLE
add opencv-python to the dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='baselines',
           'cloudpickle',
           'tensorflow>=1.4.0',
           'click',
+          'opencv-python'
       ],
       description='OpenAI baselines: high quality implementations of reinforcement learning algorithms',
       author='OpenAI',


### PR DESCRIPTION
as pointed out in https://github.com/openai/baselines/issues/342, opencv-python dependency was missing