### PR TITLE
fix undefined behavior

### DIFF
--- a/baselines/ppo1/pposgd_simple.py
+++ b/baselines/ppo1/pposgd_simple.py
@@ -68,7 +68,7 @@ def add_vtarg_and_adv(seg, gamma, lam):
     new = np.append(seg["new"], 0) # last element is only used for last vtarg, but we already zeroed it if last new = 1
     vpred = np.append(seg["vpred"], seg["nextvpred"])
     T = len(seg["rew"])
-    seg["adv"] = gaelam = np.empty(T, 'float32')
+    seg["adv"] = gaelam = np.ones(T, 'float32')
     rew = seg["rew"]
     lastgaelam = 0
     for t in reversed(range(T)):


### PR DESCRIPTION
np.empty does not initialize the new array, and since it is nowhere else initialized before its use in the surrogate loss function this is undefined behavior. Fixed it be initializing it to ones, since one is the neutral element for multiplication.