### PR TITLE
Fix DummyVecEnv reusing buffer for observation

### DIFF
--- a/baselines/common/vec_env/dummy_vec_env.py
+++ b/baselines/common/vec_env/dummy_vec_env.py
@@ -62,6 +62,6 @@ class DummyVecEnv(VecEnv):
 
     def _obs_from_buf(self):
         if self.keys==[None]:
-            return self.buf_obs[None]
+            return np.copy(self.buf_obs[None])
         else:
-            return self.buf_obs
+            return {k: np.copy(v) for k, v in self.buf_obs.items()}


### PR DESCRIPTION
DummyVecEnv historically reused buffers for the values returned by step(). This differs from the semantics of SubprocVecEnv and can lead to surprising results. @unixpickle fixed this in 8b3a6c20519a45a1387c7d23b98b55d5961f3403, but part of the change appears to have been clobbered in 69f25c6028d71e23a7b267b0e1071ad216290f91 such that the current behavior is that the _observation_ buffer is reused while reward, done and info are copied. This PR fixes this to copy the observation buffer as well. Requesting review from @unixpickle or @pzhokhov.