### PR TITLE
Add mode parameter for render in VecEnvWrapper.

### DIFF
--- a/baselines/common/vec_env/__init__.py
+++ b/baselines/common/vec_env/__init__.py
@@ -109,8 +109,8 @@ class VecEnvWrapper(VecEnv):
     def close(self):
         return self.venv.close()
 
-    def render(self):
-        self.venv.render()
+    def render(self, mode='human'):
+        return self.venv.render(mode=mode)
 
 class CloudpickleWrapper(object):
     """


### PR DESCRIPTION
The VecEnvWrapper didn't pass along the mode or return any result; I just made it more closely match the expected behavior from Env.render(). This also makes it possible for me to grab headless rendering with a 'rgb_array' mode.