### PR TITLE
Update subproc_vec_env.py

### DIFF
--- a/baselines/common/vec_env/subproc_vec_env.py
+++ b/baselines/common/vec_env/subproc_vec_env.py
@@ -29,7 +29,7 @@ def worker(remote, parent_remote, env_fn_wrapper):
 
 
 class SubprocVecEnv(VecEnv):
-    def __init__(self, env_fns, spaces=None):
+    def __init__(self, env_fns, spaces=None, worker=worker):
         """
         envs: list of gym environments to run in subprocesses
         """


### PR DESCRIPTION
Allow worker to be defined externally. If SubprocVecEnv is subclassed new attributes in the subclass can now be accessed if defined in the worker.