### PR TITLE
fixed HER nan warning

### DIFF
--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -116,7 +116,7 @@ class RolloutWorker:
                     return self.generate_rollouts()
 
             if np.isnan(o_new).any():
-                self.logger.warning('NaN caught during rollout generation. Trying again...')
+                self.logger.warn('NaN caught during rollout generation. Trying again...')
                 self.reset_all_rollouts()
                 return self.generate_rollouts()
 


### PR DESCRIPTION
In the HER RolloutWorker there is an if statement which catches if the environment returned any nan values in the observation. If there are, it calls logger.warning(). But the logger does not have a warning() function. I believe it is meant to be warn().
