### PR TITLE
Fix evaluation switch in DDPG

### DIFF
--- a/baselines/ddpg/main.py
+++ b/baselines/ddpg/main.py
@@ -29,7 +29,6 @@ def run(env_id, seed, noise_type, layer_norm, evaluation, **kwargs):
     if evaluation and rank==0:
         eval_env = gym.make(env_id)
         eval_env = bench.Monitor(eval_env, os.path.join(logger.get_dir(), 'gym_eval'))
-        env = bench.Monitor(env, None)
     else:
         eval_env = None
 

--- a/baselines/ddpg/training.py
+++ b/baselines/ddpg/training.py
@@ -158,9 +158,9 @@ def train(env, nb_epochs, nb_epoch_cycles, render_eval, reward_scale, render, pa
             combined_stats['rollout/actions_std'] = np.std(epoch_actions)
             # Evaluation statistics.
             if eval_env is not None:
-                combined_stats['eval/return'] = eval_episode_rewards
+                combined_stats['eval/return'] = np.mean(eval_episode_rewards)
                 combined_stats['eval/return_history'] = np.mean(eval_episode_rewards_history)
-                combined_stats['eval/Q'] = eval_qs
+                combined_stats['eval/Q_mean'] = np.mean(eval_qs)
                 combined_stats['eval/episodes'] = len(eval_episode_rewards)
             def as_scalar(x):
                 if isinstance(x, np.ndarray):


### PR DESCRIPTION
tested on:

```sh
python -m baselines.ddpg.main --env-id "HalfCheetah-v2" --evaluation # fixed
python -m baselines.ddpg.main --env-id "HalfCheetah-v2" --evaluation --render-eval # fixed
python -m baselines.ddpg.main --env-id "HalfCheetah-v2" 
python -m baselines.ddpg.main --env-id "HalfCheetah-v2" --render
```