### PR TITLE
Seed the same in vectorized mujoco environments

### DIFF
--- a/baselines/run.py
+++ b/baselines/run.py
@@ -91,7 +91,7 @@ def build_env(args):
                                    inter_op_parallelism_threads=1))
 
         if args.num_env:
-            env = SubprocVecEnv([lambda: make_mujoco_env(env_id, seed + i if seed is not None else None, args.reward_scale) for i in range(args.num_env)])    
+            env = SubprocVecEnv([(lambda y: (lambda: make_mujoco_env(env_id, seed + y if seed is not None else None, args.reward_scale)))(i) for i in range(args.num_env)]) 
         else:
             env = DummyVecEnv([lambda: make_mujoco_env(env_id, seed, args.reward_scale)])
 


### PR DESCRIPTION
I investigated a bit and  found out that the seed (when not None) is the same in every parallel environment due to the particular behaviour of lambda.
To reproduce this finding you can run 
```
python -m baselines.run --env=HalfCheetah-v2 --num_env=8 --seed=0
```
and add a
```
print(seed)
```
in make_mujoco_env function in baselines/baselines/common/cmd_utils.py and it should output 
```
7
7
7
7
7
7
7
7
```
This is due to the particular behaviour of lambda. This is discussed here:
https://stackoverflow.com/questions/6076270/python-lambda-function-in-list-comprehensions
(see second answer)
With this fix it now ouputs:
```
0
1
2
3
4
5
6
7
```
Which I think is the expected behaviour.

Cheers!