### PR TITLE
ncpu needs to be an integer.

### DIFF
--- a/baselines/run.py
+++ b/baselines/run.py
@@ -74,7 +74,7 @@ def train(args, extra_args):
 
 def build_env(args):
     ncpu = multiprocessing.cpu_count()
-    if sys.platform == 'darwin': ncpu /= 2
+    if sys.platform == 'darwin': ncpu //= 2
     nenv = args.num_env or ncpu
     alg = args.alg
     rank = MPI.COMM_WORLD.Get_rank() if MPI else 0


### PR DESCRIPTION
I encountered the following error when running `python -m baselines.run --alg=ppo2 --env=PongNoFrameskip-v4 --num_timesteps=1000 --save_path=./pong_1K_ppo2` on macos with Python3.5.3:

```
File "/Users/xxxx/p/baselines/baselines/common/cmd_util.py", line 41, in make_vec_env
    if num_env > 1: return SubprocVecEnv([make_env(i + start_index) for i in range(num_env)])
TypeError: 'float' object cannot be interpreted as an integer
```

It's because I didn't specify `--num_env`, so it defaults to `ncpu / 2` which is a float.