### PR TITLE
Error when dimension of stack differs

### DIFF
--- a/baselines/common/vec_env/vec_frame_stack.py
+++ b/baselines/common/vec_env/vec_frame_stack.py
@@ -20,13 +20,13 @@ class VecFrameStack(VecEnvWrapper):
         for (i, new) in enumerate(news):
             if new:
                 self.stackedobs[i] = 0
-        self.stackedobs[..., -obs.shape[-1]:] = obs
+        self.stackedobs[..., -1] = obs
         return self.stackedobs, rews, news, infos
 
     def reset(self):
         obs = self.venv.reset()
         self.stackedobs[...] = 0
-        self.stackedobs[..., -obs.shape[-1]:] = obs
+        self.stackedobs[..., -1] = obs
         return self.stackedobs
 
     def close(self):


### PR DESCRIPTION
stackedobs has the dimensions [stacks, env_obs, stacks]... In every step we should we be updating only the last stack, right? So we should update last instance of stack self.stackedobs[..., -1] = obs
Otherwise you get errors like:
ValueError: could not broadcast input array from shape (16,4) into shape (16,4,4)