### PR TITLE
Adding num_env to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ python -m baselines.run --alg=ppo2 --env=PongNoFrameskip-v4 --num_timesteps=2e7 
 ```
 This should get to the mean reward per episode about 20. To load and visualize the model, we'll do the following - load the model, train it for 0 steps, and then visualize: 
 ```bash
-python -m baselines.run --alg=ppo2 --env=PongNoFrameskip-v4 --num_timesteps=0 --load_path=~/models/pong_20M_ppo2 --play
+python -m baselines.run --alg=ppo2 --env=PongNoFrameskip-v4 --num_timesteps=0 --num_env=4 --load_path=~/models/pong_20M_ppo2 --play
 ```
 
 *NOTE:* At the moment Mujoco training uses VecNormalize wrapper for the environment which is not being saved correctly; so loading the models trained on Mujoco will not work well if the environment is recreated. If necessary, you can work around that by replacing RunningMeanStd by TfRunningMeanStd in [baselines/common/vec_env/vec_normalize.py](baselines/common/vec_env/vec_normalize.py#L12). This way, mean and std of environment normalizing wrapper will be saved in tensorflow variables and included in the model file; however, training is slower that way - hence not including it by default

--- a/baselines/run.py
+++ b/baselines/run.py
@@ -222,7 +222,7 @@ def main():
         env = build_env(args)
         obs = env.reset()
         def initialize_placeholders(nlstm=128,**kwargs):
-            return np.zeros((args.num_env, 2*nlstm)), np.zeros((1))
+            return np.zeros((args.num_env or 0, 2*nlstm)), np.zeros((1))
         state, dones = initialize_placeholders(**extra_args)
         while True:
             actions, _, state, _ = model.step(obs,S=state, M=dones)


### PR DESCRIPTION
There is a bug in the current README file that causes this example to throw an error. The error thrown by

`python -m baselines.run --alg=ppo2 --env=PongNoFrameskip-v4 --num_timesteps=0 --load_path=~/models/pong_20M_ppo2 --play`

is

`[...]"/openai/baselines/baselines/run.py", line 227, in initialize_placeholders
    return np.zeros((args.num_env, 2*nlstm)), np.zeros((1))
TypeError: 'NoneType' object cannot be interpreted as an integer`

I added `--num_env=4` to the example, and I also fixed the underlying bug where it assumes that args.num_env is an integer. (I'm not sure I used best-practices for that change, so feel free to suggest a different fix.)