### PR TITLE
pip install . let's us flake8 code even when using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
     - docker build . -t baselines-test
 
 before_script:
-    - git clone https://github.com/openai/baselines -o source_code
     - pip install flake8
+    - git clone https://github.com/openai/baselines source_code
     - flake8 source_code --show-source --statistics
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
     - docker
 
 install:
+    - pip install .
     - pip install flake8
     - docker build . -t baselines-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ services:
     - docker
 
 install:
-    - pip install tensorflow
-    - pip install .
-    - pip install flake8
     - docker build . -t baselines-test
 
-script:
+before_script:
+    - git clone https://github.com/openai/baselines
+    - pip install flake8
     - flake8 . --show-source --statistics
+
+script:
     - docker run baselines-test pytest -v .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
     - docker
 
 install:
+    - pip install tensorflow
     - pip install .
     - pip install flake8
     - docker build . -t baselines-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ install:
     - docker build . -t baselines-test
 
 before_script:
-    - git clone https://github.com/openai/baselines
+    - git clone https://github.com/openai/baselines -o source_code
     - pip install flake8
-    - flake8 . --show-source --statistics
+    - flake8 source_code --show-source --statistics
 
 script:
     - docker run baselines-test pytest -v .


### PR DESCRIPTION
I _finally_ understand the comments made in #605...  Using Docker overrides the Travis default of doing __pip install .__ so let's do it manually so we can flake8 test our code.