### PR TITLE
Fix --play for DQN

### DIFF
--- a/baselines/deepq/deepq.py
+++ b/baselines/deepq/deepq.py
@@ -47,6 +47,9 @@ class ActWrapper(object):
         return self._act(*args, **kwargs)
 
     def step(self, observation, **kwargs):
+        # DQN doesn't use RNNs so we ignore states and masks
+        kwargs.pop('S', None)
+        kwargs.pop('M', None)
         return self._act([observation], **kwargs), None, None, None
 
     def save_act(self, path=None):


### PR DESCRIPTION
When trying to use `--play` with DQN:

`python -m baselines.run --alg=deepq --env=SeaquestNoFrameskip-v4 --num_timesteps 0 --play`

It gives the following error:

`TypeError: act() got an unexpected keyword argument 'S'`

Since DQN doesn't use RNNs (which is what I think states and masks are used for?), proposed PR has DQN's `step` function just ignore the `S` and `M` arguments.