### PR TITLE
Set allow_growth=True for MuJoCo sessions

### DIFF
--- a/baselines/run.py
+++ b/baselines/run.py
@@ -121,9 +121,11 @@ def build_env(args):
         env = retro_wrappers.wrap_deepmind_retro(env)
 
     else:
-       get_session(tf.ConfigProto(allow_soft_placement=True,
-                                   intra_op_parallelism_threads=1,
-                                   inter_op_parallelism_threads=1))
+       config = tf.ConfigProto(allow_soft_placement=True,
+                               intra_op_parallelism_threads=1,
+                               inter_op_parallelism_threads=1)
+       config.gpu_options.allow_growth = True
+       get_session(config=config)
 
        env = make_vec_env(env_id, env_type, args.num_env or 1, seed, reward_scale=args.reward_scale)
 


### PR DESCRIPTION
Training on MuJoCo environments currently uses a default session set up by `run.py`. Currently this session is not set up with `allow_growth = True`, resulting in training taking up all GPU memory available.

I'm also confused why we don't just do `get_session()` here, though, which would just use a `config` with sensible defaults. Why are `intra_op_parallelism_threads=1` and `inter_op_parallelism_threads=1` important here? OK, for MuJoCo environments we default to a single environment, but surely there's no harm in still parallelising TensorFlow computations? (@pzhokhov, as far as I can tell from the git blame, you introduced these lines - maybe you could shed some light?)

Thanks!