### PR TITLE
disable gym subpackages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='baselines',
       packages=[package for package in find_packages()
                 if package.startswith('baselines')],
       install_requires=[
-          'gym[mujoco,atari,classic_control,robotics]',
+          'gym',
           'scipy',
           'tqdm',
           'joblib',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ if sys.version_info.major != 3:
 extras = {
     'test': [
         'filelock',
-        'pytest'
+        'pytest',
+        'gym[atari]'
     ],
     'bullet': [
         'pybullet',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras = {
     'test': [
         'filelock',
         'pytest',
-        'gym[atari]'
+        'atari-py'
     ],
     'bullet': [
         'pybullet',


### PR DESCRIPTION
the installation of latest mujoco-py fails if mujoco is not present; so baselines that requires gym[mujoco] that requires mujoco-py fails as well.  On the other hand, we don't actually need that for baselines to work