### PR TITLE
Adds description of param_noise parameter in deepq.learn method

### DIFF
--- a/baselines/deepq/deepq.py
+++ b/baselines/deepq/deepq.py
@@ -169,6 +169,8 @@ def learn(env,
         to 1.0. If set to None equals to total_timesteps.
     prioritized_replay_eps: float
         epsilon to add to the TD errors when updating priorities.
+    param_noise: bool
+        whether or not to use parameter space noise (https://arxiv.org/abs/1706.01905)
     callback: (locals, globals) -> None
         function called at every steps with state of the algorithm.
         If callback returns true training stops.


### PR DESCRIPTION
The `learn` method inside deepq.py had a parameter [`param_noise`](https://github.com/openai/baselines/blob/583ba082a2ade49455030f38374e889874b885fd/baselines/deepq/deepq.py#L116) with no explanation in its docstring. This was now added.