### PR TITLE
DDPG has unused 'seed' argument 

### DIFF
--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -7,7 +7,7 @@ from baselines.ddpg.ddpg_learner import DDPG
 from baselines.ddpg.models import Actor, Critic
 from baselines.ddpg.memory import Memory
 from baselines.ddpg.noise import AdaptiveParamNoiseSpec, NormalActionNoise, OrnsteinUhlenbeckActionNoise
-
+from baselines.common import set_global_seeds
 import baselines.common.tf_util as U
 
 from baselines import logger
@@ -41,6 +41,7 @@ def learn(network, env,
           param_noise_adaption_interval=50,
           **network_kwargs):
 
+    set_global_seeds(seed)
 
     if total_timesteps is not None:
         assert nb_epochs is None


### PR DESCRIPTION
DeepQ, PPO2, ACER, trpo_mpi, A2C, and ACKTR have the code for:

from baselines.common import set_global_seeds
...
def learn(...):
...
   set_global_seeds(seed)
DDPG has the argument 'seed=None' but doesn't have the two lines of code needed to set the global seeds.