### PR TITLE
[VecEnv]: add action clipping wrapper

### DIFF
--- a/baselines/common/vec_env/vec_action_clip.py
+++ b/baselines/common/vec_env/vec_action_clip.py
@@ -1,0 +1,17 @@
+from . import VecEnvWrapper
+import numpy as np
+
+
+class VecActionClip(VecEnvWrapper):
+    def step_async(self, actions):
+        low = self.action_space.low
+        high = self.action_space.high
+        actions = [np.clip(action, low, high) for action in actions]
+        
+        self.venv.step_async(actions)
+    
+    def step_wait(self):
+        return self.venv.step_wait()
+    
+    def reset(self):
+        return self.venv.reset()


### PR DESCRIPTION
Hi @pzhokhov , do you think this wrapper can be useful ?

This might be very convenient for certain continuous control environments where the policy network might sample action outside the bounds. And it avoids runtime error for the users without writing their own clipping. 

Another advantage is that in policy gradient methods, sometimes people make mistake to calculate log-probability of sampled action after doing clipping, this will in fact transform the underlying distributions and may degrade the performance. By providing this wrapper, it tries to avoid this mistake from users side. 