### PR TITLE
Fix to training HER + DDPG with demos

### DIFF
--- a/baselines/her/ddpg.py
+++ b/baselines/her/ddpg.py
@@ -367,8 +367,6 @@ class DDPG(object):
             self.pi_loss_tf = -tf.reduce_mean(self.main.Q_pi_tf)
             self.pi_loss_tf += self.action_l2 * tf.reduce_mean(tf.square(self.main.pi_tf / self.max_u))
 
-        self.pi_loss_tf = -tf.reduce_mean(self.main.Q_pi_tf)
-        self.pi_loss_tf += self.action_l2 * tf.reduce_mean(tf.square(self.main.pi_tf / self.max_u))
         Q_grads_tf = tf.gradients(self.Q_loss_tf, self._vars('main/Q'))
         pi_grads_tf = tf.gradients(self.pi_loss_tf, self._vars('main/pi'))
         assert len(self._vars('main/Q')) == len(Q_grads_tf)


### PR DESCRIPTION
A recent merge (#474) for training DDPG + HER with demonstrations has no effect due any change to actor loss being overwritten after the `if` branching logic. This pull request fixes this issue.