### PR TITLE
remove one of duplicated lines.

### DIFF
--- a/baselines/ppo2/ppo2.py
+++ b/baselines/ppo2/ppo2.py
@@ -160,7 +160,6 @@ def learn(*, network, env, total_timesteps, eval_env = None, seed=None, nsteps=2
             envsperbatch = nenvs // nminibatches
             envinds = np.arange(nenvs)
             flatinds = np.arange(nenvs * nsteps).reshape(nenvs, nsteps)
-            envsperbatch = nbatch_train // nsteps
             for _ in range(noptepochs):
                 np.random.shuffle(envinds)
                 for start in range(0, nenvs, envsperbatch):


### PR DESCRIPTION
Both results of following lines are same.
1) `envsperbatch = nenvs // nminibatches` at line:160
2) `envsperbatch = nbatch_train // nsteps`  at line:163
because of `nbath = nenvs * nsteps` and `nbatch_train = nbatch // nminibatches` at line:98-99.

First one is proper because it is more closer to the variable name, `envsperbatch`.

Thank you.
