### PR TITLE
run.py framestack bug fix

### DIFF
--- a/baselines/common/cmd_util.py
+++ b/baselines/common/cmd_util.py
@@ -75,6 +75,8 @@ def make_env(env_id, env_type, mpi_rank=0, subrank=0, seed=None, reward_scale=1.
     if env_type == 'atari':
         env = wrap_deepmind(env, **wrapper_kwargs)
     elif env_type == 'retro':
+        if 'frame_stack' not in wrapper_kwargs:
+            wrapper_kwargs['frame_stack'] = 1
         env = retro_wrappers.wrap_deepmind_retro(env, **wrapper_kwargs)
 
     if reward_scale != 1:


### PR DESCRIPTION
Fixes the run.py script so that framestack is not applied twice for retro games.

Testing: 
```
from baselines.common.cmd_util import common_arg_parser
from baselines.run import build_env
args = common_arg_parser().parse_args(['--env', 'SpaceInvaders-Snes'])
build_env(args).observation_space
```
now outputs `Box(84, 84, 4)` instead of `Box(84, 84, 16)`.