### PR TITLE
Update dataset.py

### DIFF
--- a/baselines/common/dataset.py
+++ b/baselines/common/dataset.py
@@ -7,7 +7,8 @@ class Dataset(object):
         self.enable_shuffle = shuffle
         self.n = next(iter(data_map.values())).shape[0]
         self._next_id = 0
-        self.shuffle()
+        if shuffle:
+            self.shuffle()
 
     def shuffle(self):
         if self.deterministic:


### PR DESCRIPTION
The `Dataset` class shuffles the dataset even when `shuffle` is set to False. This creates issues for recurrent policies.