### PR TITLE
[Update vec_normalize.py] Avoid first reward to be very large

### DIFF
--- a/baselines/common/vec_env/vec_normalize.py
+++ b/baselines/common/vec_env/vec_normalize.py
@@ -25,7 +25,8 @@ class VecNormalize(VecEnvWrapper):
         obs = self._obfilt(obs)
         if self.ret_rms:
             self.ret_rms.update(self.ret)
-            rews = np.clip(rews / np.sqrt(self.ret_rms.var + self.epsilon), -self.cliprew, self.cliprew)
+            if self.ret_rms.count >= 2:
+                rews = np.clip(rews / np.sqrt(self.ret_rms.var + self.epsilon), -self.cliprew, self.cliprew)
         self.ret[news] = 0.
         return obs, rews, news, infos
 


### PR DESCRIPTION
I've tested in Mujoco environments, it seems current reward normalization results in the first reward to have very large magnitude and being clipped at +10/-10. Perhaps it is better to keep first reward unchanged and start normalization from the second one. 