### PR TITLE
Fix indexing LazyFrames

### DIFF
--- a/baselines/common/atari_wrappers.py
+++ b/baselines/common/atari_wrappers.py
@@ -221,7 +221,7 @@ class LazyFrames(object):
         return len(self._force())
 
     def __getitem__(self, i):
-        return self._force()[i]
+        return self._force()[..., i]
 
 def make_atari(env_id, max_episode_steps=None):
     env = gym.make(env_id)


### PR DESCRIPTION
In current version, indexing i-th element of LazyFrame return wrong result.
It stores the stacked frame in (height, width, channel) format but using first axis -which is height- when indexing, therefore return value has (width, channel) shape.

----------------
```python
from baselines.common.atari_wrappers import make_atari, wrap_deepmind

env = wrap_deepmind(make_atari('PongNoFrameskip-v4'), frame_stack=True)

state = env.reset()
print(type(state))
print(state[0].shape)
```

The result of above snippet is
```python
<class 'baselines.common.atari_wrappers.LazyFrames'>
(84, 4)
```
for now, but it would be
```python
<class 'baselines.common.atari_wrappers.LazyFrames'>
(84, 84)
```
after the fix.