### PR TITLE
_check_shape now really checking for shape

### DIFF
--- a/baselines/common/tf_util.py
+++ b/baselines/common/tf_util.py
@@ -404,13 +404,16 @@ def adjust_shape(placeholder, data):
 def _check_shape(placeholder_shape, data_shape):
     ''' check if two shapes are compatible (i.e. differ only by dimensions of size 1, or by the batch dimension)'''
 
-    return True
+    if placeholder_shape[0] == -1 or data_shape[0] == -1:
+        placeholder_shape = placeholder_shape[1:]
+        data_shape = data_shape[1:]
+
     squeezed_placeholder_shape = _squeeze_shape(placeholder_shape)
     squeezed_data_shape = _squeeze_shape(data_shape)
 
     for i, s_data in enumerate(squeezed_data_shape):
         s_placeholder = squeezed_placeholder_shape[i]
-        if s_placeholder != -1 and s_data != s_placeholder:
+        if s_data != s_placeholder:
             return False
 
     return True


### PR DESCRIPTION
`_check_shape` was always returning `True`. When I was building a custom model, this lead to much more confusing error messages than  [`adjust_shape`](https://github.com/openai/baselines/blob/master/baselines/common/tf_util.py#L399) would have thrown if `_check_shape` worked correctly.  


After removing the `return True` line, I noticed that `_check_shape` did not work correctly when passing a batch shape with only one sample and the shape with batch dimension. I thus modified `_squeeze_shape` to also squeeze away the batch dim (-1). 

In my use cases (PPO, DQN, A2C) everything works as expected now.

Script to check the function:

```python
from baselines.common.tf_util import _check_shape

s1, s2 = (1, 20), (-1, 20)
_check_shape(s1, s2)
```

After removing `return True` as first line in `_check_shape`, the third line in this example returned `False`, although the comment in `_check_shape` suggests otherwise. This PR fixes this issue.