### PR TITLE
Fix converting list of LazyFrames to ndarray

### DIFF
--- a/baselines/common/atari_wrappers.py
+++ b/baselines/common/atari_wrappers.py
@@ -254,6 +254,13 @@ class LazyFrames(object):
         return len(self._force())
 
     def __getitem__(self, i):
+        return self._force()[i]
+
+    def count(self):
+        frames = self._force()
+        return frames.shape[frames.ndim - 1]
+
+    def frame(self, i):
         return self._force()[..., i]
 
 def make_atari(env_id, max_episode_steps=None):


### PR DESCRIPTION
Fix for issue #892. PR #875 changed behavior of \_\_getitem\_\_ method of [LazyFrames ](https://github.com/openai/baselines/blob/9b68103b737ac46bc201dfb3121cfa5df2127e53/baselines/common/atari_wrappers.py#L229) class. So, numpy wasn't able to convert list of LazyFrames instances in an [util method](https://github.com/openai/baselines/blob/9b68103b737ac46bc201dfb3121cfa5df2127e53/baselines/common/tf_util.py#L394).
I offer to reverse changes from #875, and introduce interface for getting count of frames and specific frames for LazyFrames instance.
Example of usage:
```python
import numpy as np
from baselines.common.atari_wrappers import make_atari, wrap_deepmind

env = wrap_deepmind(make_atari('PongNoFrameskip-v4'), frame_stack=True)

state = env.reset()

print(type(state))
print(state.count())
print(state.frame(0).shape)

print(np.array([state]).shape)
```
The result:
```
<class 'baselines.common.atari_wrappers.LazyFrames'>
4
(84, 84)
(1, 84, 84, 4)
```