### PR TITLE
Support Tuple observation spaces

### DIFF
--- a/baselines/common/vec_env/util.py
+++ b/baselines/common/vec_env/util.py
@@ -38,6 +38,9 @@ def obs_space_info(obs_space):
     if isinstance(obs_space, gym.spaces.Dict):
         assert isinstance(obs_space.spaces, OrderedDict)
         subspaces = obs_space.spaces
+    elif isinstance(obs_space, gym.spaces.Tuple):
+        assert isinstance(obs_space.spaces, tuple)
+        subspaces = {i: obs_space.spaces[i] for i in range(len(obs_space.spaces))}
     else:
         subspaces = {None: obs_space}
     keys = []


### PR DESCRIPTION
This PR adds support for Tuple observation spaces. Without this PR, using `VecEnv` with Tuple observation spaces gives the following error:

```
  envs = DummyVecEnv(envs)
  File "/usr/local/lib/python3.7/site-packages/baselines/common/vec_env/dummy_vec_env.py", line 24, in __init__
    self.buf_obs = { k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k]) for k in self.keys }
  File "/usr/local/lib/python3.7/site-packages/baselines/common/vec_env/dummy_vec_env.py", line 24, in <dictcomp>
    self.buf_obs = { k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k]) for k in self.keys }
TypeError: 'NoneType' object is not iterable
```