### PR TITLE
call the close function of my env

### DIFF
--- a/baselines/common/vec_env/dummy_vec_env.py
+++ b/baselines/common/vec_env/dummy_vec_env.py
@@ -16,9 +16,9 @@ class DummyVecEnv(VecEnv):
         env_fns: iterable of callables      functions that build environments
         """
         self.envs = [fn() for fn in env_fns]
-        env = self.envs[0]
-        VecEnv.__init__(self, len(env_fns), env.observation_space, env.action_space)
-        obs_space = env.observation_space
+        self.env = self.envs[0]
+        VecEnv.__init__(self, len(env_fns), self.env.observation_space, self.env.action_space)
+        obs_space = self.env.observation_space
         self.keys, shapes, dtypes = obs_space_info(obs_space)
 
         self.buf_obs = { k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k]) for k in self.keys }
@@ -79,3 +79,6 @@ class DummyVecEnv(VecEnv):
             return self.envs[0].render(mode=mode)
         else:
             return super().render(mode=mode)
+
+    def close_extras(self):
+        self.env.env.close()


### PR DESCRIPTION
When a training is finished using baselines.run, I need  that the close function of my own environment be called to do a final task or print a message. I suggest this change that is fine for me