### PR TITLE
Starting to reassign waiting_step in shmem_vecenv

### DIFF
--- a/baselines/common/vec_env/shmem_vec_env.py
+++ b/baselines/common/vec_env/shmem_vec_env.py
@@ -70,9 +70,11 @@ class ShmemVecEnv(VecEnv):
         assert len(actions) == len(self.parent_pipes)
         for pipe, act in zip(self.parent_pipes, actions):
             pipe.send(('step', act))
+        self.waiting_step = True
 
     def step_wait(self):
         outs = [pipe.recv() for pipe in self.parent_pipes]
+        self.waiting_step = False
         obs, rews, dones, infos = zip(*outs)
         return self._decode_obses(obs), np.array(rews), np.array(dones), infos
 


### PR DESCRIPTION
"self.waiting_step" is initialized in __init__ function but it is not reassigned anywhere.
Because it is used in reset function and close_extras function, it should be fixed.
So i fixed it to be similar with subproc_vec_env's one.