### PR TITLE
suppress excessive messages from unused loggers

### DIFF
--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -394,7 +394,8 @@ def configure(dir=None, format_strs=None, comm=None, log_suffix=''):
     output_formats = [make_output_format(f, dir, log_suffix) for f in format_strs]
 
     Logger.CURRENT = Logger(dir=dir, output_formats=output_formats, comm=comm)
-    log('Logging to %s'%dir)
+    if output_formats:
+        log('Logging to %s'%dir)
 
 def _configure_default_logger():
     configure()


### PR DESCRIPTION
Only print the "logging to [dir]" message when the logger has something to output. Running with the new spawn change and both mpi and subprocvecenv, there are many "logging to [dir]" messages but most are not logging anything.