### PR TITLE
Graph Networks support

### DIFF
--- a/baselines/deepq/replay_buffer.py
+++ b/baselines/deepq/replay_buffer.py
@@ -35,12 +35,12 @@ class ReplayBuffer(object):
         for i in idxes:
             data = self._storage[i]
             obs_t, action, reward, obs_tp1, done = data
-            obses_t.append(np.array(obs_t, copy=False))
-            actions.append(np.array(action, copy=False))
+            obses_t.append(obs_t)
+            actions.append(action)
             rewards.append(reward)
-            obses_tp1.append(np.array(obs_tp1, copy=False))
+            obses_tp1.append(obs_tp1)
             dones.append(done)
-        return np.array(obses_t), np.array(actions), np.array(rewards), np.array(obses_tp1), np.array(dones)
+        return obses_t, actions, rewards, obses_tp1, dones
 
     def sample(self, batch_size):
         """Sample a batch of experiences.


### PR DESCRIPTION
I'm implementing a deepq agent using [graph neural networks](https://github.com/deepmind/graph_nets) as a Q-network.

That means that observations are graphs and (at least in my case) the edges represent possible actions. The graph_net transforms an input graph into an output graph, which has the q-values in the edges. The interesting thing about this is that observation-space and action-space sizes are *variable*.

These are the minimal changes I had to make in order to support graph_nets. They are not ready to be merged, they currently break existing functionality.

Is there interest in having this upstreamed? If so, I'd appreciate some comments how best to do that. The main challenges were

- assumption that `num_actions` is a constant (replaced by taking the number of columns of the q-value matrix instead)
- assumption that the observations are numpy arrays (why does the replay buffer convert to numpy arrays?)