### PR TITLE
Add ability for DDPG to resume training, ensure observation to DDPG critic is flattened

### DIFF
--- a/baselines/ddpg/ddpg.py
+++ b/baselines/ddpg/ddpg.py
@@ -42,6 +42,7 @@ def learn(network, env,
           tau=0.01,
           eval_env=None,
           param_noise_adaption_interval=50,
+          load_path=None,
           **network_kwargs):
 
     set_global_seeds(seed)
@@ -99,6 +100,8 @@ def learn(network, env,
     sess = U.get_session()
     # Prepare everything.
     agent.initialize(sess)
+    if load_path is not None:
+        agent.load(load_path)
     sess.graph.finalize()
 
     agent.reset()

--- a/baselines/ddpg/ddpg_learner.py
+++ b/baselines/ddpg/ddpg_learner.py
@@ -146,6 +146,12 @@ class DDPG(object):
 
         self.initial_state = None # recurrent architectures not supported yet
 
+    def save(self, path):
+        U.save_variables(path, sess=self.sess)
+
+    def load(self, path):
+        U.load_variables(path, sess=self.sess)
+
     def setup_target_network_updates(self):
         actor_init_updates, actor_soft_updates = get_target_updates(self.actor.vars, self.target_actor.vars, self.tau)
         critic_init_updates, critic_soft_updates = get_target_updates(self.critic.vars, self.target_critic.vars, self.tau)

--- a/baselines/ddpg/models.py
+++ b/baselines/ddpg/models.py
@@ -40,7 +40,8 @@ class Critic(Model):
 
     def __call__(self, obs, action, reuse=False):
         with tf.variable_scope(self.name, reuse=tf.AUTO_REUSE):
-            x = tf.concat([obs, action], axis=-1) # this assumes observation and action can be concatenated
+            x = tf.layers.flatten(obs)
+            x = tf.concat([x, action], axis=-1) # this assumes observation and action can be concatenated
             x = self.network_builder(x)
             x = tf.layers.dense(x, 1, kernel_initializer=tf.random_uniform_initializer(minval=-3e-3, maxval=3e-3), name='output')
         return x


### PR DESCRIPTION
Fixes two little things:

1. Add saving and loading of all the variables used in DDPG, just like is done in A2C. This fixes #935.
2. baselines.ddpg.models.Critic wasn't ensuring that the observation and action have compatible dimensions before concatenating them. I've fixed this by adding an extra flatten applied to the observation input before the concatenation takes place.