### PR TITLE
Replace default value of traj_limitation to be of int type

### DIFF
--- a/baselines/gail/dataset/mujoco_dset.py
+++ b/baselines/gail/dataset/mujoco_dset.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument("--expert_path", type=str, default="../data/deterministic.trpo.Hopper.0.00.npz")
-    parser.add_argument("--traj_limitation", type=int, default=None)
+    parser.add_argument("--traj_limitation", type=int, default=-1)
     parser.add_argument("--plot", type=bool, default=False)
     args = parser.parse_args()
     test(args.expert_path, args.traj_limitation, args.plot)


### PR DESCRIPTION
A negative `traj_limitation` value corresponds to having no trajectory limit (Line 45-46), which seems like a suitable default.

Fixes issue #951 
