### PR TITLE
Allow actor network's output layer to have any activation function

### DIFF
--- a/baselines/common/distributions.py
+++ b/baselines/common/distributions.py
@@ -39,7 +39,7 @@ class PdType(object):
         raise NotImplementedError
     def pdfromflat(self, flat):
         return self.pdclass()(flat)
-    def pdfromlatent(self, latent_vector, init_scale, init_bias):
+    def pdfromlatent(self, latent_vector, init_scale, init_bias, activation=None):
         raise NotImplementedError
     def param_shape(self):
         raise NotImplementedError
@@ -61,8 +61,8 @@ class CategoricalPdType(PdType):
         self.ncat = ncat
     def pdclass(self):
         return CategoricalPd
-    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0):
-        pdparam = _matching_fc(latent_vector, 'pi', self.ncat, init_scale=init_scale, init_bias=init_bias)
+    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0, activation=None):
+        pdparam = _matching_fc(latent_vector, 'pi', self.ncat, init_scale=init_scale, init_bias=init_bias, activation=activation)
         return self.pdfromflat(pdparam), pdparam
 
     def param_shape(self):
@@ -82,8 +82,8 @@ class MultiCategoricalPdType(PdType):
     def pdfromflat(self, flat):
         return MultiCategoricalPd(self.ncats, flat)
 
-    def pdfromlatent(self, latent, init_scale=1.0, init_bias=0.0):
-        pdparam = _matching_fc(latent, 'pi', self.ncats.sum(), init_scale=init_scale, init_bias=init_bias)
+    def pdfromlatent(self, latent, init_scale=1.0, init_bias=0.0, activation=None):
+        pdparam = _matching_fc(latent, 'pi', self.ncats.sum(), init_scale=init_scale, init_bias=init_bias, activation=activation)
         return self.pdfromflat(pdparam), pdparam
 
     def param_shape(self):
@@ -123,8 +123,8 @@ class BernoulliPdType(PdType):
         return [self.size]
     def sample_dtype(self):
         return tf.int32
-    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0):
-        pdparam = _matching_fc(latent_vector, 'pi', self.size, init_scale=init_scale, init_bias=init_bias)
+    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0, activation=None):
+        pdparam = _matching_fc(latent_vector, 'pi', self.size, init_scale=init_scale, init_bias=init_bias, activation=activation)
         return self.pdfromflat(pdparam), pdparam
 
 # WRONG SECOND DERIVATIVES

--- a/baselines/common/distributions.py
+++ b/baselines/common/distributions.py
@@ -99,8 +99,8 @@ class DiagGaussianPdType(PdType):
     def pdclass(self):
         return DiagGaussianPd
 
-    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0):
-        mean = _matching_fc(latent_vector, 'pi', self.size, init_scale=init_scale, init_bias=init_bias)
+    def pdfromlatent(self, latent_vector, init_scale=1.0, init_bias=0.0, activation=None):
+        mean = _matching_fc(latent_vector, 'pi', self.size, init_scale=init_scale, init_bias=init_bias, activation=activation)
         logstd = tf.get_variable(name='pi/logstd', shape=[1, self.size], initializer=tf.zeros_initializer())
         pdparam = tf.concat([mean, mean * 0.0 + logstd], axis=1)
         return self.pdfromflat(pdparam), mean
@@ -348,8 +348,11 @@ def validate_probtype(probtype, pdparam):
     print('ok on', probtype, pdparam)
 
 
-def _matching_fc(tensor, name, size, init_scale, init_bias):
+def _matching_fc(tensor, name, size, init_scale, init_bias, activation=None):
     if tensor.shape[-1] == size:
         return tensor
     else:
-        return fc(tensor, name, size, init_scale=init_scale, init_bias=init_bias)
+        h = fc(tensor, name, size, init_scale=init_scale, init_bias=init_bias)
+        if activation:
+            h = activation(h)
+        return h

--- a/baselines/common/policies.py
+++ b/baselines/common/policies.py
@@ -15,7 +15,7 @@ class PolicyWithValue(object):
     Encapsulates fields and methods for RL policy and value function estimation with shared parameters
     """
 
-    def __init__(self, env, observations, latent, estimate_q=False, vf_latent=None, sess=None, **tensors):
+    def __init__(self, env, observations, latent, estimate_q=False, vf_latent=None, sess=None, activation=None, **tensors):
         """
         Parameters:
         ----------
@@ -46,7 +46,7 @@ class PolicyWithValue(object):
         # Based on the action space, will select what probability distribution type
         self.pdtype = make_pdtype(env.action_space)
 
-        self.pd, self.pi = self.pdtype.pdfromlatent(latent, init_scale=0.01)
+        self.pd, self.pi = self.pdtype.pdfromlatent(latent, init_scale=0.01, activation=activation)
 
         # Take an action
         self.action = self.pd.sample()
@@ -118,7 +118,7 @@ class PolicyWithValue(object):
     def load(self, load_path):
         tf_util.load_state(load_path, sess=self.sess)
 
-def build_policy(env, policy_network, value_network=None,  normalize_observations=False, estimate_q=False, **policy_kwargs):
+def build_policy(env, policy_network, value_network=None,  normalize_observations=False, estimate_q=False, activation=None, **policy_kwargs):
     if isinstance(policy_network, str):
         network_type = policy_network
         policy_network = get_network_builder(network_type)(**policy_kwargs)
@@ -172,6 +172,7 @@ def build_policy(env, policy_network, value_network=None,  normalize_observation
             vf_latent=vf_latent,
             sess=sess,
             estimate_q=estimate_q,
+            activation=activation,
             **extra_tensors
         )
         return policy


### PR DESCRIPTION
At present, it isn't possible to easily create an actor network that has an activation function for its output layer while still sharing the hidden layers with the critic network. The only way is to have two separate networks. This PR fixes that, resolving #953  that I opened to discuss adding this feature.