### PR TITLE
error in t range

### DIFF
--- a/baselines/her/rollout.py
+++ b/baselines/her/rollout.py
@@ -65,7 +65,7 @@ class RolloutWorker:
         dones = []
         info_values = [np.empty((self.T - 1, self.rollout_batch_size, self.dims['info_' + key]), np.float32) for key in self.info_keys]
         Qs = []
-        for t in range(self.T):
+        for t in range(self.T-1):
             policy_output = self.policy.get_actions(
                 o, ag, self.g,
                 compute_Q=self.compute_Q,


### PR DESCRIPTION
On this [line](https://github.com/openai/baselines/blob/c57528573ea695b19cd03e98dae48f0082fb2b5e/baselines/her/rollout.py#L66) info_values is defined as a list with a numpy element of shape (self.T-1,...)

Next on this [line](https://github.com/openai/baselines/blob/c57528573ea695b19cd03e98dae48f0082fb2b5e/baselines/her/rollout.py#L68), t is initialized to vary from [0, self.T-1]

However on this [line](https://github.com/openai/baselines/blob/c57528573ea695b19cd03e98dae48f0082fb2b5e/baselines/her/rollout.py#L103), when t becomes self.T-1, from info_values on the second dimention, self.T-1 index is accessed which is not possible as the size on that dimension is self.T-1