### PR TITLE
entrypoint variable made public

### DIFF
--- a/baselines/run.py
+++ b/baselines/run.py
@@ -32,7 +32,7 @@ except ImportError:
 _game_envs = defaultdict(set)
 for env in gym.envs.registry.all():
     # TODO: solve this with regexes
-    env_type = env._entry_point.split(':')[0].split('.')[-1]
+    env_type = env.entry_point.split(':')[0].split('.')[-1]
     _game_envs[env_type].add(env.id)
 
 # reading benchmark names directly from retro requires
@@ -126,7 +126,7 @@ def get_env_type(args):
 
     # Re-parse the gym registry, since we could have new envs since last time.
     for env in gym.envs.registry.all():
-        env_type = env._entry_point.split(':')[0].split('.')[-1]
+        env_type = env.entry_point.split(':')[0].split('.')[-1]
         _game_envs[env_type].add(env.id)  # This is a set so add is idempotent
 
     if env_id in _game_envs.keys():


### PR DESCRIPTION
Hello!
With a recent commit in openai gym (openai/gym@dc91f43) the entry_point variable was changed from private to public, thus breaking baselines/baselines/run.py script.
Updating baselines/run.py in lines 35 and 129 from
env_type = env._entry_point.split(':')[0].split('.')[-1]
to
env_type = env.entry_point.split(':')[0].split('.')[-1]
fixes this problem. I hope, this can be useful.

Best regards,
Nico Bach