### PR TITLE
fix a bug in acer saving and loading model

### DIFF
--- a/baselines/acer/acer.py
+++ b/baselines/acer/acer.py
@@ -6,7 +6,7 @@ from baselines import logger
 
 from baselines.common import set_global_seeds
 from baselines.common.policies import build_policy
-from baselines.common.tf_util import get_session, save_variables
+from baselines.common.tf_util import get_session, save_variables, load_variables
 from baselines.common.vec_env.vec_frame_stack import VecFrameStack
 
 from baselines.a2c.utils import batch_to_seq, seq_to_batch
@@ -216,7 +216,8 @@ class Model(object):
 
 
         self.train = train
-        self.save = functools.partial(save_variables, sess=sess, variables=params)
+        self.save = functools.partial(save_variables, sess=sess)
+        self.load = functools.partial(load_variables, sess=sess)
         self.train_model = train_model
         self.step_model = step_model
         self._step = _step
@@ -357,6 +358,9 @@ def learn(network, env, seed=None, nsteps=20, total_timesteps=int(80e6), q_coef=
                   max_grad_norm=max_grad_norm, lr=lr, rprop_alpha=rprop_alpha, rprop_epsilon=rprop_epsilon,
                   total_timesteps=total_timesteps, lrschedule=lrschedule, c=c,
                   trust_region=trust_region, alpha=alpha, delta=delta)
+
+    if load_path is not None:
+        model.load(load_path)
 
     runner = Runner(env=env, model=model, nsteps=nsteps)
     if replay_ratio > 0:


### PR DESCRIPTION
There is bug in acer algorithm to save and load trained models. At first, train the model using acer method and save it. Then load the saved mode. The model did not learn anything and seems to be a random or initial model.

It could be tested by the following case:

OPENAI_LOGDIR=$HOME/logs/cartpole-acer-ori OPENAI_LOG_FORMAT=tensorboard python -m baselines.run --alg=acer --env=CartPole-v0 --num_timesteps=1e5 --nsteps=32 --save_path=~/models/choice_acer-ori
python -m baselines.run --alg=acer --env=CartPole-v0 --num_timesteps=0 --nsteps=32 --load_path=~/models/choice_acer-ori --play

The tensorborad shows that  the mean reward per episode is around 200 at the end of training.  But the load and visualize model shows that the mean reward per episode is around 22 which could be done by random model.
