### PR TITLE
fixed missing monitor files of deepq and trpo_mpi

### DIFF
--- a/baselines/run.py
+++ b/baselines/run.py
@@ -94,9 +94,11 @@ def build_env(args):
 
     if env_type in {'atari', 'retro'}:
         if alg == 'deepq':
-            env = make_env(env_id, env_type, seed=seed, wrapper_kwargs={'frame_stack': True})
+            env = make_env(env_id, env_type, seed=seed, wrapper_kwargs={'frame_stack': True},
+                           logger_dir=logger.get_dir())
         elif alg == 'trpo_mpi':
-            env = make_env(env_id, env_type, seed=seed)
+            env = make_env(env_id, env_type, seed=seed, logger_dir=logger.get_dir(),
+                           mpi_rank=logger.get_rank_without_mpi_import())
         else:
             frame_stack_size = 4
             env = make_vec_env(env_id, env_type, nenv, seed, gamestate=args.gamestate, reward_scale=args.reward_scale)


### PR DESCRIPTION
added logger_dir argument, so  the results writer of the Monitor wrapper will  be set
added mpi_rank argument, so each mpi process uses its own monitor file

see #1008 