### PR TITLE
Minor documentation, fix numpy warning at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ src
 .cache
 
 MUJOCO_LOG.TXT
+.vscode/

--- a/baselines/deepq/deepq.py
+++ b/baselines/deepq/deepq.py
@@ -306,8 +306,9 @@ def learn(env,
                 # Update target network periodically.
                 update_target()
 
-            mean_100ep_reward = round(np.mean(episode_rewards[-100:]), 1)
             num_episodes = len(episode_rewards)
+            mean_100ep_reward = round(np.mean(episode_rewards[-101:-1]), 1) if \
+                num_episodes > 1 else 0.0
             if done and print_freq is not None and len(episode_rewards) % print_freq == 0:
                 logger.record_tabular("steps", t)
                 logger.record_tabular("episodes", num_episodes)

--- a/baselines/deepq/deepq.py
+++ b/baselines/deepq/deepq.py
@@ -306,7 +306,7 @@ def learn(env,
                 # Update target network periodically.
                 update_target()
 
-            mean_100ep_reward = round(np.mean(episode_rewards[-101:-1]), 1)
+            mean_100ep_reward = round(np.mean(episode_rewards[-100:]), 1)
             num_episodes = len(episode_rewards)
             if done and print_freq is not None and len(episode_rewards) % print_freq == 0:
                 logger.record_tabular("steps", t)

--- a/baselines/deepq/experiments/train_pong.py
+++ b/baselines/deepq/experiments/train_pong.py
@@ -5,8 +5,13 @@ from baselines.common.atari_wrappers import make_atari
 
 
 def main():
+    # by default CSV logs will be created in OS temp directory
     logger.configure()
+
+    # create Atari environment, use no-op reset, max pool last two frames
     env = make_atari('PongNoFrameskip-v4')
+
+    # by default monitor will log episod reward and log
     env = bench.Monitor(env, logger.get_dir())
     env = deepq.wrap_atari_dqn(env)
 

--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -380,7 +380,7 @@ def configure(dir=None, format_strs=None, comm=None, log_suffix=''):
             datetime.datetime.now().strftime("openai-%Y-%m-%d-%H-%M-%S-%f"))
     assert isinstance(dir, str)
     dir = os.path.expanduser(dir)
-    os.makedirs(dir, exist_ok=True)
+    os.makedirs(os.path.expanduser(dir), exist_ok=True)
 
     rank = get_rank_without_mpi_import()
     if rank > 0:

--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -380,7 +380,8 @@ def configure(dir=None, format_strs=None, comm=None, log_suffix=''):
             datetime.datetime.now().strftime("openai-%Y-%m-%d-%H-%M-%S-%f"))
     assert isinstance(dir, str)
     dir = os.path.expanduser(dir)
-    os.makedirs(os.path.expanduser(dir), exist_ok=True)
+    os.makedirs(dir, exist_ok=True)
+    print('Log directry:', dir) # Let user know where log files will be put
 
     rank = get_rank_without_mpi_import()
     if rank > 0:

--- a/baselines/logger.py
+++ b/baselines/logger.py
@@ -381,7 +381,6 @@ def configure(dir=None, format_strs=None, comm=None, log_suffix=''):
     assert isinstance(dir, str)
     dir = os.path.expanduser(dir)
     os.makedirs(dir, exist_ok=True)
-    print('Log directry:', dir) # Let user know where log files will be put
 
     rank = get_rank_without_mpi_import()
     if rank > 0:


### PR DESCRIPTION
Currently while running `train_pong.py` we get following numpy warning:

```
C:\ProgramData\Anaconda3\lib\site-packages\numpy\core\fromnumeric.py:3118: RuntimeWarning: Mean of empty slice.
```
This is because current code tries to do `episode_rewards[-101:-1]` on array of size 1. The simple fix only does that if size > 1.

Also, added few comments train_pong.py.