### PR TITLE
GAIL-PPO

### DIFF
--- a/baselines/gail/adversary.py
+++ b/baselines/gail/adversary.py
@@ -26,7 +26,7 @@ class TransitionClassifier(object):
         self.num_actions = env.action_space.shape[0]
         self.hidden_size = hidden_size
         self.build_ph()
-        # Build grpah
+        # Build graph
         generator_logits = self.build_graph(self.generator_obs_ph, self.generator_acs_ph, reuse=False)
         expert_logits = self.build_graph(self.expert_obs_ph, self.expert_acs_ph, reuse=True)
         # Build accuracy

--- a/baselines/gail/pposgd_simple.py
+++ b/baselines/gail/pposgd_simple.py
@@ -1,0 +1,190 @@
+from baselines.common import Dataset, dataset, explained_variance, fmt_row, zipsame
+from baselines import logger
+import baselines.common.tf_util as U
+import tensorflow as tf, numpy as np
+import time
+from baselines.common.mpi_adam import MpiAdam
+from baselines.common.mpi_moments import mpi_moments
+from mpi4py import MPI
+from collections import deque
+from baselines.gail.utils import traj_segment_generator, add_vtarg_and_adv, flatten_lists, Discriminator
+
+def learn(env, policy_fn, reward_giver, expert_dataset, rank,
+        pretrained, pretrained_weight, *,
+        g_step, d_step,
+        timesteps_per_actorbatch, # timesteps per actor per update
+        clip_param, entcoeff, # clipping parameter epsilon, entropy coeff
+        optim_epochs, optim_stepsize, optim_batchsize,# optimization hypers
+        gamma, lam, # advantage estimation
+        max_timesteps=0, max_episodes=0, max_iters=0, max_seconds=0,  # time constraint
+        callback=None, # you can do anything in the callback, since it takes locals(), globals()
+        adam_epsilon=1e-5,
+        schedule='constant' # annealing for stepsize parameters (epsilon and adam)
+        ):
+
+    nworkers = MPI.COMM_WORLD.Get_size()
+    rank = MPI.COMM_WORLD.Get_rank()
+    np.set_printoptions(precision=3)
+    # Setup losses and stuff
+    # ----------------------------------------
+    ob_space = env.observation_space
+    ac_space = env.action_space
+    pi = policy_fn("pi", ob_space, ac_space) # Construct network for new policy
+    oldpi = policy_fn("oldpi", ob_space, ac_space) # Network for old policy
+    atarg = tf.placeholder(dtype=tf.float32, shape=[None]) # Target advantage function (if applicable)
+    ret = tf.placeholder(dtype=tf.float32, shape=[None]) # Empirical return
+
+    lrmult = tf.placeholder(name='lrmult', dtype=tf.float32, shape=[]) # learning rate multiplier, updated with schedule
+
+    ob = U.get_placeholder_cached(name="ob")
+    ac = pi.pdtype.sample_placeholder([None])
+
+    kloldnew = oldpi.pd.kl(pi.pd)
+    ent = pi.pd.entropy()
+    meankl = tf.reduce_mean(kloldnew)
+    meanent = tf.reduce_mean(ent)
+    pol_entpen = (-entcoeff) * meanent
+
+    ratio = tf.exp(pi.pd.logp(ac) - oldpi.pd.logp(ac)) # pnew / pold
+    surr1 = ratio * atarg # surrogate from conservative policy iteration
+    surr2 = tf.clip_by_value(ratio, 1.0 - clip_param, 1.0 + clip_param) * atarg #
+    pol_surr = - tf.reduce_mean(tf.minimum(surr1, surr2)) # PPO's pessimistic surrogate (L^CLIP)
+    vf_loss = tf.reduce_mean(tf.square(pi.vpred - ret))
+    total_loss = pol_surr + pol_entpen + vf_loss
+    losses = [pol_surr, pol_entpen, vf_loss, meankl, meanent]
+    loss_names = ["pol_surr", "pol_entpen", "vf_loss", "kl", "ent"]
+
+    var_list = pi.get_trainable_variables()
+    get_flat = U.GetFlat(var_list)
+    set_from_flat = U.SetFromFlat(var_list)
+    lossandgrad = U.function([ob, ac, atarg, ret, lrmult], losses + [U.flatgrad(total_loss, var_list)])
+    d_adam = MpiAdam(reward_giver.get_trainable_variables())
+    adam = MpiAdam(var_list, epsilon=adam_epsilon)
+
+    assign_old_eq_new = U.function([],[], updates=[tf.assign(oldv, newv)
+        for (oldv, newv) in zipsame(oldpi.get_variables(), pi.get_variables())])
+    compute_losses = U.function([ob, ac, atarg, ret, lrmult], losses)
+
+    def allmean(x):
+        assert isinstance(x, np.ndarray)
+        out = np.empty_like(x)
+        MPI.COMM_WORLD.Allreduce(x, out, op=MPI.SUM)
+        out /= nworkers
+        return out
+
+    U.initialize()
+    th_init = get_flat()
+    MPI.COMM_WORLD.Bcast(th_init, root=0)
+    set_from_flat(th_init)
+    d_adam.sync()
+    adam.sync()
+
+    if rank == 0:
+        print("Init param sum", th_init.sum(), flush=True)
+
+
+    # Prepare for rollouts
+    # ----------------------------------------
+    seg_gen = traj_segment_generator(pi, env, reward_giver, timesteps_per_actorbatch, stochastic=True)
+
+    disc = Discriminator(reward_giver, expert_dataset, d_adam, d_step, optim_stepsize, nworkers)
+
+    episodes_so_far = 0
+    timesteps_so_far = 0
+    iters_so_far = 0
+    tstart = time.time()
+    lenbuffer = deque(maxlen=100) # rolling buffer for episode lengths
+    rewbuffer = deque(maxlen=100) # rolling buffer for episode rewards
+    true_rewbuffer = deque(maxlen=100)
+
+    assert sum([max_iters>0, max_timesteps>0, max_episodes>0, max_seconds>0])==1, "Only one time constraint permitted"
+
+    while True:
+        if callback: callback(locals(), globals())
+        if max_timesteps and timesteps_so_far >= max_timesteps:
+            break
+        elif max_episodes and episodes_so_far >= max_episodes:
+            break
+        elif max_iters and iters_so_far >= max_iters:
+            break
+        elif max_seconds and time.time() - tstart >= max_seconds:
+            break
+
+        if schedule == 'constant':
+            cur_lrmult = 1.0
+        elif schedule == 'linear':
+            cur_lrmult =  max(1.0 - float(timesteps_so_far) / max_timesteps, 0)
+        else:
+            raise NotImplementedError
+
+        logger.log("********** Iteration %i ************"%iters_so_far)
+
+        # ------------------ Update G ------------------
+        logger.log("Optimizing Policy...")
+
+        seg = seg_gen.__next__()
+        add_vtarg_and_adv(seg, gamma, lam)
+
+        # ob, ac, atarg, ret, td1ret = map(np.concatenate, (obs, acs, atargs, rets, td1rets))
+        ob, ac, atarg, tdlamret = seg["ob"], seg["ac"], seg["adv"], seg["tdlamret"]
+        vpredbefore = seg["vpred"] # predicted value function before udpate
+        atarg = (atarg - atarg.mean()) / atarg.std() # standardized advantage function estimate
+        d = Dataset(dict(ob=ob, ac=ac, atarg=atarg, vtarg=tdlamret), deterministic=pi.recurrent)
+        optim_batchsize = optim_batchsize or ob.shape[0]
+
+        if hasattr(pi, "ob_rms"): pi.ob_rms.update(ob) # update running mean/std for policy
+
+        assign_old_eq_new() # set old parameter values to new parameter values
+
+        # Here we do a bunch of optimization epochs over the data
+        logger.log(fmt_row(13, loss_names))
+        for _ in range(optim_epochs):
+            losses = [] # list of tuples, each of which gives the loss for a minibatch
+            for batch in d.iterate_once(optim_batchsize):
+                *newlosses, g = lossandgrad(batch["ob"], batch["ac"], batch["atarg"], batch["vtarg"], cur_lrmult)
+                adam.update(allmean(g), optim_stepsize * cur_lrmult)
+                losses.append(newlosses)
+            logger.log(fmt_row(13, np.mean(losses, axis=0)))
+
+        logger.log("Evaluating losses...")
+        losses = []
+        for batch in d.iterate_once(optim_batchsize):
+            newlosses = compute_losses(batch["ob"], batch["ac"], batch["atarg"], batch["vtarg"], cur_lrmult)
+            losses.append(newlosses)
+        meanlosses,_,_ = mpi_moments(losses, axis=0)
+        logger.log(fmt_row(13, meanlosses))
+
+        for (lossval, name) in zipsame(meanlosses, loss_names):
+            logger.record_tabular("loss_"+name, lossval)
+        logger.record_tabular("ev_tdlam_before", explained_variance(vpredbefore, tdlamret))
+
+        # ------------------ Update D ------------------
+        logger.log("Optimizing Discriminator...")
+        d_losses = disc.update(ob, ac)
+        logger.log(fmt_row(13, reward_giver.loss_name))
+        logger.log(fmt_row(13, np.mean(d_losses, axis=0)))
+
+        lrlocal = (seg["ep_lens"], seg["ep_rets"], seg["ep_true_rets"]) # local values
+        listoflrpairs = MPI.COMM_WORLD.allgather(lrlocal) # list of tuples
+        lens, rews, true_rets = map(flatten_lists, zip(*listoflrpairs))
+        lenbuffer.extend(lens)
+        rewbuffer.extend(rews)
+        true_rewbuffer.extend(true_rets)
+
+        logger.record_tabular("EpLenMean", np.mean(lenbuffer))
+        logger.record_tabular("EpRewMean", np.mean(rewbuffer))
+        logger.record_tabular("EpTrueRewMean", np.mean(true_rewbuffer))
+        logger.record_tabular("EpThisIter", len(lens))
+        episodes_so_far += len(lens)
+        timesteps_so_far += sum(lens)
+        iters_so_far += 1
+
+        logger.record_tabular("EpisodesSoFar", episodes_so_far)
+        logger.record_tabular("TimestepsSoFar", timesteps_so_far)
+        logger.record_tabular("TimeElapsed", time.time() - tstart)
+
+        if rank == 0:
+            logger.dump_tabular()
+
+    return pi
+

--- a/baselines/gail/utils.py
+++ b/baselines/gail/utils.py
@@ -1,0 +1,128 @@
+import numpy as np
+from mpi4py import MPI
+from baselines.common import dataset
+
+def traj_segment_generator(pi, env, reward_giver, horizon, stochastic):
+    t = 0
+    ac = env.action_space.sample() # not used, just so we have the datatype
+    new = True # marks if we're on first timestep of an episode
+    ob = env.reset()
+
+    cur_ep_ret = 0 # return in current episode
+    cur_ep_true_ret = 0
+    cur_ep_len = 0 # len of current episode
+    ep_true_rets = []
+    ep_rets = [] # returns of completed episodes in this segment
+    ep_lens = [] # lengths of ...
+
+    # Initialize history arrays
+    obs = np.array([ob for _ in range(horizon)])
+    true_rews = np.zeros(horizon, 'float32')
+    rews = np.zeros(horizon, 'float32')
+    vpreds = np.zeros(horizon, 'float32')
+    news = np.zeros(horizon, 'int32')
+    acs = np.array([ac for _ in range(horizon)])
+    prevacs = acs.copy()
+
+    while True:
+        prevac = ac
+        ac, vpred = pi.act(stochastic, ob)
+        # Slight weirdness here because we need value function at time T
+        # before returning segment [0, T-1] so we get the correct
+        # terminal value
+        if t > 0 and t % horizon == 0:
+            yield {"ob" : obs, "rew" : rews, "vpred" : vpreds, "new" : news,
+                    "ac" : acs, "prevac" : prevacs, "nextvpred": vpred * (1 - new),
+                    "ep_rets" : ep_rets, "ep_lens" : ep_lens, "ep_true_rets": ep_true_rets}
+            # Be careful!!! if you change the downstream algorithm to aggregate
+            # several of these batches, then be sure to do a deepcopy
+            ep_rets = []
+            ep_true_rets = []
+            ep_lens = []
+        i = t % horizon
+        obs[i] = ob
+        vpreds[i] = vpred
+        news[i] = new
+        acs[i] = ac
+        prevacs[i] = prevac
+
+        rew = reward_giver.get_reward(ob, ac)
+        ob, true_rew, new, _ = env.step(ac)
+        # ob, rew, new, _ = env.step(ac)
+        # true_rew = rew
+        rews[i] = rew
+        true_rews[i] = true_rew
+
+        cur_ep_ret += rew
+        cur_ep_true_ret += true_rew
+        cur_ep_len += 1
+        if new:
+            ep_rets.append(cur_ep_ret)
+            ep_true_rets.append(cur_ep_true_ret)
+            ep_lens.append(cur_ep_len)
+            cur_ep_ret = 0
+            cur_ep_true_ret = 0
+            cur_ep_len = 0
+            ob = env.reset()
+        t += 1
+
+def add_vtarg_and_adv(seg, gamma, lam):
+    """
+    Compute target value using TD(lambda) estimator, and advantage with GAE(lambda)
+    """
+    new = np.append(seg["new"], 0) # last element is only used for last vtarg, but we already zeroed it if last new = 1
+    vpred = np.append(seg["vpred"], seg["nextvpred"])
+    T = len(seg["rew"])
+    seg["adv"] = gaelam = np.empty(T, 'float32')
+    rew = seg["rew"]
+    lastgaelam = 0
+    for t in reversed(range(T)):
+        nonterminal = 1-new[t+1]
+        delta = rew[t] + gamma * vpred[t+1] * nonterminal - vpred[t]
+        gaelam[t] = lastgaelam = delta + gamma * lam * nonterminal * lastgaelam
+    seg["tdlamret"] = seg["adv"] + seg["vpred"]
+
+def flatten_lists(listoflists):
+    return [el for list_ in listoflists for el in list_]
+
+def allmean(x, nworkers):
+    assert isinstance(x, np.ndarray)
+    out = np.empty_like(x)
+    MPI.COMM_WORLD.Allreduce(x, out, op=MPI.SUM)
+    out /= nworkers
+    return out
+
+class Discriminator:
+    def __init__(self, reward_giver, expert_dataset, d_optim, d_step, d_stepsize, nworkers):
+        self.reward_giver = reward_giver
+        self.expert_dataset = expert_dataset
+        self.d_step = d_step
+        self.d_stepsize = d_stepsize
+        self.d_optim = d_optim
+        self.nworkers = nworkers
+
+    def update(self, ob, ac):
+        """
+        Updates discriminator with a policy's generated observations and actions.
+        Parameters:
+            ob (list): A trajectory of observations.
+            ac (list): A trajectory of actions.
+        Returns:
+            d_losses (list): The losses for the discriminator.
+        """
+        ob_expert, ac_expert = self.expert_dataset.get_next_batch(len(ob))
+        batch_size = len(ob) // self.d_step
+        d_losses = []  # list of tuples, each of which gives the loss for a minibatch
+        for ob_batch, ac_batch in dataset.iterbatches((ob, ac),
+                                                      include_final_partial_batch=False,
+                                                      batch_size=batch_size):
+            ob_expert, ac_expert = self.expert_dataset.get_next_batch(len(ob_batch))
+            # update running mean/std for reward_giver
+            if hasattr(self.reward_giver, "obs_rms"): self.reward_giver.obs_rms.update(np.concatenate((ob_batch, ob_expert), 0))
+            *newlosses, g = self.reward_giver.lossandgrad(ob_batch, ac_batch, ob_expert, ac_expert)
+            self.d_optim.update(allmean(g, self.nworkers), self.d_stepsize)
+            d_losses.append(newlosses)
+
+        return d_losses
+
+

--- a/baselines/ppo1/run_mujoco.py
+++ b/baselines/ppo1/run_mujoco.py
@@ -22,7 +22,7 @@ def train(env_id, num_timesteps, seed):
 
 def main():
     args = mujoco_arg_parser().parse_args()
-    logger.configure()
+    logger.configure(args.log_path)
     train(args.env, num_timesteps=args.num_timesteps, seed=args.seed)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements PPO as the generator policy in GAIL. 
I noticed from the argparse methods, that PPO was supposed to be a choice, so I wondered if it was possible to support it. After some work, I have been able to get it to converge consistently, with similar performance characteristics as TRPO. For this reason, I believe it's a valuable addition to this repository. 

I've shifted some code around to make it a little less repetitive, but shouldn't change any method signatures or parameters. I did make some slight changes to the argparser, which in retrospect may be breaking, so I'm willing to go back and redo those.

The current GAIL codebase runs on TF 1.14. 

Initial Benchmarks:
![image](https://user-images.githubusercontent.com/4899332/68094546-8a278880-fe56-11e9-83d4-6fac882240eb.png)

![image](https://user-images.githubusercontent.com/4899332/68100974-0a161880-fe80-11e9-9672-adc283ee25f3.png)


GAIL-PPO has also been configured to support MPI. The graphs are not as good-looking, but I hope it helps support my case:
![image](https://user-images.githubusercontent.com/4899332/68094684-d4f5d000-fe57-11e9-9159-bf305ec6b048.png)

Some additional thoughts:
I have tried but have not had much success with integrating PPO2's implementation with GAIL. A bit more investigation led me to believe that PPO1 doesn't clip its [value loss](https://github.com/openai/baselines/blob/master/baselines/ppo1/pposgd_simple.py#L114), but PPO2 [seems to](https://github.com/openai/baselines/blob/master/baselines/ppo2/model.py#L75). I note some other suspected changes, but I'd like to know if this is worth investigating before opening up a new discussion. Thank you, I'd appreciate your time.