### PR TITLE
Fixed RuntimeWarning: invalid value encountered in double_scalars

### DIFF
--- a/baselines/deepq/deepq.py
+++ b/baselines/deepq/deepq.py
@@ -222,7 +222,12 @@ def learn(env,
             # Update target network periodically.
             model.update_target()
 
-        mean_100ep_reward = round(np.mean(episode_rewards[-101:-1]), 1)
+        # update mean_100ep_reward without division by zero
+        if len(episode_rewards[-101:-1]) == 0:
+            mean_100ep_reward = -np.inf
+        else:
+            mean_100ep_reward = round(float(np.mean(episode_rewards[-101:-1])), 1)
+            
         num_episodes = len(episode_rewards)
         if done and print_freq is not None and len(episode_rewards) % print_freq == 0:
             logger.record_tabular("steps", t)


### PR DESCRIPTION
Fixed **RuntimeWarning: invalid value encountered in double_scalars** due to zero division while calculating mean of episode rewards after every 100 episodes. 