### PR TITLE
Monitor should close what it inherits

### DIFF
--- a/baselines/bench/monitor.py
+++ b/baselines/bench/monitor.py
@@ -79,6 +79,7 @@ class Monitor(Wrapper):
         self.total_steps += 1
 
     def close(self):
+        super(Monitor, self).close()
         if self.f is not None:
             self.f.close()
 


### PR DESCRIPTION
In my work I have used a monitored environment which has some resources it needs to close. Using Monitor was the problem as it doesn't call close() on its parent. This fixes it