### PR TITLE
remove gym version upper-bound constraint.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='baselines',
       packages=[package for package in find_packages()
                 if package.startswith('baselines')],
       install_requires=[
-          'gym>=0.15.4, <0.16.0',
+          'gym>=0.15.4',
           'scipy',
           'tqdm',
           'joblib',


### PR DESCRIPTION
Package gym 0.17.2 and 0.16.0 are both ready to run.