### PR TITLE
dependency gym with soft requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='baselines',
       packages=[package for package in find_packages()
                 if package.startswith('baselines')],
       install_requires=[
-          'gym>=0.15.4, <0.16.0',
+          'gym>=0.15.4',
           'scipy',
           'tqdm',
           'joblib',


### PR DESCRIPTION
pip installation throws an error if `gym` package dependency is has a hard upper bound on version.
This should be removed as higher versions of gym can also install `baselines` without any issue.