### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ setup(name='baselines',
 # ensure there is some tensorflow build with version above 1.4
 import pkg_resources
 tf_pkg = None
-for tf_pkg_name in ['tensorflow', 'tensorflow-gpu', 'tf-nightly', 'tf-nightly-gpu']:
+for tf_pkg_name in ['tensorflow', 'tensorflow-gpu', 'tf-nightly', 'tf-nightly-gpu', 'tensorflow-macos']:
     try:
         tf_pkg = pkg_resources.get_distribution(tf_pkg_name)
     except pkg_resources.DistributionNotFound:
         pass
 assert tf_pkg is not None, 'TensorFlow needed, of version above 1.4'
-from distutils.version import LooseVersion
-assert LooseVersion(re.sub(r'-?rc\d+$', '', tf_pkg.version)) >= LooseVersion('1.4.0')
+from packaging.version import parse
+assert parse(re.sub(r'-?rc\d+$', '', tf_pkg.version)) >= parse('1.4.0')


### PR DESCRIPTION
Adding 'tensorflow-macos' for in list tf_pkg_name for the new tensorflow builds for apple silicon chips.

'distutils.LooseVersion' is depracated
replacing it with 'packaging.version.parse'  